### PR TITLE
Replace requestFullscreen() with CSS-based fullscreen for all 3 maps

### DIFF
--- a/src/components/admin/BathymetricMapEditor.tsx
+++ b/src/components/admin/BathymetricMapEditor.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useWaypoints, useCreateWaypoint, useDeleteWaypoint, getWaypointLabel, getWaypointColor, getWaypointIcon } from "@/hooks/useWaypoints";
+import { MapFullscreenToggle } from "@/components/map/MapFullscreenToggle";
 import { toast } from "sonner";
 import html2canvas from "html2canvas";
 
@@ -237,15 +238,22 @@ const BathymetricMapEditor = ({ siteId, siteName, siteLat, siteLng }: Bathymetri
         Carte marine SHOM avec les profondeurs. Cliquez pour définir la zone d'immersion.
       </p>
 
-      <div ref={mapContainerRef}>
+      <div ref={mapContainerRef} className="relative">
         <div
           ref={mapRef}
           className="w-full h-80 rounded-lg shadow-sm border border-ocean/30"
         />
-        
+        <MapFullscreenToggle
+          mapContainerRef={mapContainerRef as React.RefObject<HTMLDivElement>}
+          mapInstanceRef={mapInstanceRef}
+          bgClass="bg-white"
+          originalHeightClass="h-80"
+          mapDivRef={mapRef as React.RefObject<HTMLDivElement>}
+        />
+
         {/* Legend for PDF capture - shows numbered zones */}
         {diveZoneWaypoints.length > 0 && (
-          <div className="mt-2 p-3 bg-white rounded-lg border border-ocean/20 space-y-1">
+          <div className="absolute bottom-2 left-2 z-[1000] p-3 bg-white/90 backdrop-blur-sm rounded-lg shadow space-y-1">
             <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Légende des zones</p>
             {diveZoneWaypoints.map((waypoint, index) => (
               <div key={waypoint.id} className="flex items-center gap-2 text-sm">

--- a/src/components/admin/SatelliteWaypointEditor.tsx
+++ b/src/components/admin/SatelliteWaypointEditor.tsx
@@ -7,6 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useWaypoints, useCreateWaypoint, useDeleteWaypoint, WaypointType, getWaypointLabel, getWaypointColor, getWaypointIcon } from "@/hooks/useWaypoints";
+import { MapFullscreenToggle } from "@/components/map/MapFullscreenToggle";
 import { toast } from "sonner";
 import html2canvas from "html2canvas";
 
@@ -241,10 +242,17 @@ const SatelliteWaypointEditor = ({ siteId, siteName, siteLat, siteLng }: Satelli
         Cliquez sur la carte pour ajouter un point de sécurité. La vue satellite permet un positionnement précis.
       </p>
 
-      <div ref={mapContainerRef}>
+      <div ref={mapContainerRef} className="relative">
         <div
           ref={mapRef}
           className="w-full h-80 rounded-lg shadow-sm border border-border"
+        />
+        <MapFullscreenToggle
+          mapContainerRef={mapContainerRef as React.RefObject<HTMLDivElement>}
+          mapInstanceRef={mapInstanceRef}
+          bgClass="bg-black"
+          originalHeightClass="h-80"
+          mapDivRef={mapRef as React.RefObject<HTMLDivElement>}
         />
       </div>
 

--- a/src/components/map/MapFullscreenToggle.tsx
+++ b/src/components/map/MapFullscreenToggle.tsx
@@ -1,0 +1,118 @@
+import { useState, useEffect, useCallback, RefObject } from "react";
+import { Maximize2, Minimize2, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface MapFullscreenToggleProps {
+  mapContainerRef: RefObject<HTMLDivElement>;
+  mapInstanceRef: RefObject<L.Map | null>;
+  /** Background class applied to the container in fullscreen mode (default: "bg-white") */
+  bgClass?: string;
+  /** Original height class on the inner map div to restore when exiting fullscreen */
+  originalHeightClass?: string;
+  /** Ref to the inner map div whose height toggles between originalHeightClass and h-full */
+  mapDivRef?: RefObject<HTMLDivElement>;
+}
+
+const FULLSCREEN_CLASSES = ["fixed", "inset-0", "z-[9999]"];
+
+const MapFullscreenToggle = ({
+  mapContainerRef,
+  mapInstanceRef,
+  bgClass = "bg-white",
+  originalHeightClass = "h-80",
+  mapDivRef,
+}: MapFullscreenToggleProps) => {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const enterFullscreen = useCallback(() => {
+    const container = mapContainerRef.current;
+    if (!container) return;
+
+    FULLSCREEN_CLASSES.forEach((cls) => container.classList.add(cls));
+    container.classList.add(bgClass);
+
+    // Make the inner map div fill the container
+    if (mapDivRef?.current) {
+      mapDivRef.current.classList.remove(originalHeightClass);
+      mapDivRef.current.classList.add("h-full");
+    }
+
+    setIsFullscreen(true);
+
+    setTimeout(() => {
+      mapInstanceRef.current?.invalidateSize();
+    }, 200);
+  }, [mapContainerRef, mapInstanceRef, bgClass, originalHeightClass, mapDivRef]);
+
+  const exitFullscreen = useCallback(() => {
+    const container = mapContainerRef.current;
+    if (!container) return;
+
+    FULLSCREEN_CLASSES.forEach((cls) => container.classList.remove(cls));
+    container.classList.remove(bgClass);
+
+    // Restore original height on the inner map div
+    if (mapDivRef?.current) {
+      mapDivRef.current.classList.remove("h-full");
+      mapDivRef.current.classList.add(originalHeightClass);
+    }
+
+    setIsFullscreen(false);
+
+    setTimeout(() => {
+      mapInstanceRef.current?.invalidateSize();
+    }, 200);
+  }, [mapContainerRef, mapInstanceRef, bgClass, originalHeightClass, mapDivRef]);
+
+  const toggle = useCallback(() => {
+    if (isFullscreen) {
+      exitFullscreen();
+    } else {
+      enterFullscreen();
+    }
+  }, [isFullscreen, enterFullscreen, exitFullscreen]);
+
+  // Listen for Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isFullscreen) {
+        exitFullscreen();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isFullscreen, exitFullscreen]);
+
+  return (
+    <>
+      {/* Fullscreen toggle button (icon) */}
+      <Button
+        variant="secondary"
+        size="icon"
+        className="absolute top-2.5 left-2.5 z-[1000] bg-white shadow-md hover:bg-gray-100"
+        onClick={toggle}
+        title={isFullscreen ? "Quitter le plein écran" : "Plein écran"}
+      >
+        {isFullscreen ? (
+          <Minimize2 className="h-4 w-4 text-primary" />
+        ) : (
+          <Maximize2 className="h-4 w-4 text-primary" />
+        )}
+      </Button>
+
+      {/* Mobile exit button (visible only in fullscreen) */}
+      {isFullscreen && (
+        <button
+          onClick={exitFullscreen}
+          className="absolute top-2.5 right-2.5 z-[1000] flex items-center gap-1.5 rounded-lg bg-white/90 backdrop-blur-sm px-3 py-2 text-sm font-medium text-gray-700 shadow-md hover:bg-white"
+        >
+          <X className="h-4 w-4" />
+          Quitter
+        </button>
+      )}
+    </>
+  );
+};
+
+export { MapFullscreenToggle };
+export type { MapFullscreenToggleProps };


### PR DESCRIPTION
The browser Fullscreen API caused tile disappearance and Dialog inaccessibility bugs. This replaces it with a position:fixed CSS approach (fixed inset-0 z-[9999]) as recommended by Leaflet docs.

- Create reusable MapFullscreenToggle component with Escape key support and mobile exit button
- Apply to main map (Map.tsx), satellite editor, and bathymetric editor
- Legends now render as absolute overlays visible in fullscreen mode

https://claude.ai/code/session_015h6dPKqXiDRA9cubicPMx5