### PR TITLE
Fix fullscreen: use React state instead of DOM classList manipulation

### DIFF
--- a/src/components/admin/BathymetricMapEditor.tsx
+++ b/src/components/admin/BathymetricMapEditor.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useWaypoints, useCreateWaypoint, useDeleteWaypoint, getWaypointLabel, getWaypointColor, getWaypointIcon } from "@/hooks/useWaypoints";
-import { MapFullscreenToggle } from "@/components/map/MapFullscreenToggle";
+import { useMapFullscreen, MapFullscreenButtons } from "@/components/map/MapFullscreenToggle";
 import { toast } from "sonner";
 import html2canvas from "html2canvas";
 
@@ -31,6 +31,8 @@ const BathymetricMapEditor = ({ siteId, siteName, siteLat, siteLng }: Bathymetri
   const markersRef = useRef<L.Marker[]>([]);
   const tempMarkerRef = useRef<L.Marker | null>(null);
   
+  const { isFullscreen, toggle: toggleFullscreen, exitFullscreen } = useMapFullscreen({ mapInstanceRef });
+
   const [isAddingMode, setIsAddingMode] = useState(false);
   const [newPointName, setNewPointName] = useState("Zone de plongée");
   const [clickedCoords, setClickedCoords] = useState<{ lat: number; lng: number } | null>(null);
@@ -238,17 +240,15 @@ const BathymetricMapEditor = ({ siteId, siteName, siteLat, siteLng }: Bathymetri
         Carte marine SHOM avec les profondeurs. Cliquez pour définir la zone d'immersion.
       </p>
 
-      <div ref={mapContainerRef} className="relative">
+      <div ref={mapContainerRef} className={`relative ${isFullscreen ? "fixed inset-0 z-[9999] bg-white" : ""}`}>
         <div
           ref={mapRef}
-          className="w-full h-80 rounded-lg shadow-sm border border-ocean/30"
+          className={`w-full ${isFullscreen ? "h-full" : "h-80"} rounded-lg shadow-sm border border-ocean/30`}
         />
-        <MapFullscreenToggle
-          mapContainerRef={mapContainerRef as React.RefObject<HTMLDivElement>}
-          mapInstanceRef={mapInstanceRef}
-          bgClass="bg-white"
-          originalHeightClass="h-80"
-          mapDivRef={mapRef as React.RefObject<HTMLDivElement>}
+        <MapFullscreenButtons
+          isFullscreen={isFullscreen}
+          onToggle={toggleFullscreen}
+          onExit={exitFullscreen}
         />
 
         {/* Legend for PDF capture - shows numbered zones */}

--- a/src/components/admin/SatelliteWaypointEditor.tsx
+++ b/src/components/admin/SatelliteWaypointEditor.tsx
@@ -7,7 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useWaypoints, useCreateWaypoint, useDeleteWaypoint, WaypointType, getWaypointLabel, getWaypointColor, getWaypointIcon } from "@/hooks/useWaypoints";
-import { MapFullscreenToggle } from "@/components/map/MapFullscreenToggle";
+import { useMapFullscreen, MapFullscreenButtons } from "@/components/map/MapFullscreenToggle";
 import { toast } from "sonner";
 import html2canvas from "html2canvas";
 
@@ -32,6 +32,8 @@ const SatelliteWaypointEditor = ({ siteId, siteName, siteLat, siteLng }: Satelli
   const markersRef = useRef<L.Marker[]>([]);
   const tempMarkerRef = useRef<L.Marker | null>(null);
   
+  const { isFullscreen, toggle: toggleFullscreen, exitFullscreen } = useMapFullscreen({ mapInstanceRef });
+
   const [isAddingMode, setIsAddingMode] = useState(false);
   const [newPointType, setNewPointType] = useState<WaypointType>("parking");
   const [newPointName, setNewPointName] = useState("");
@@ -242,17 +244,15 @@ const SatelliteWaypointEditor = ({ siteId, siteName, siteLat, siteLng }: Satelli
         Cliquez sur la carte pour ajouter un point de sécurité. La vue satellite permet un positionnement précis.
       </p>
 
-      <div ref={mapContainerRef} className="relative">
+      <div ref={mapContainerRef} className={`relative ${isFullscreen ? "fixed inset-0 z-[9999] bg-black" : ""}`}>
         <div
           ref={mapRef}
-          className="w-full h-80 rounded-lg shadow-sm border border-border"
+          className={`w-full ${isFullscreen ? "h-full" : "h-80"} rounded-lg shadow-sm border border-border`}
         />
-        <MapFullscreenToggle
-          mapContainerRef={mapContainerRef as React.RefObject<HTMLDivElement>}
-          mapInstanceRef={mapInstanceRef}
-          bgClass="bg-black"
-          originalHeightClass="h-80"
-          mapDivRef={mapRef as React.RefObject<HTMLDivElement>}
+        <MapFullscreenButtons
+          isFullscreen={isFullscreen}
+          onToggle={toggleFullscreen}
+          onExit={exitFullscreen}
         />
       </div>
 

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -13,7 +13,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useLocations, useCreateLocation, Location } from "@/hooks/useLocations";
 import { useUserRole } from "@/hooks/useUserRole";
-import { MapFullscreenToggle } from "@/components/map/MapFullscreenToggle";
+import { useMapFullscreen, MapFullscreenButtons } from "@/components/map/MapFullscreenToggle";
 import { toast } from "sonner";
 
 // Haversine formula to calculate distance between two GPS points (in km)
@@ -82,6 +82,7 @@ const Map = () => {
   const [isLocating, setIsLocating] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const { isOrganizer } = useUserRole();
+  const { isFullscreen, toggle: toggleFullscreen, exitFullscreen } = useMapFullscreen({ mapInstanceRef });
   const navigate = useNavigate();
 
   // State for create location dialog
@@ -487,11 +488,11 @@ const Map = () => {
           <div className="grid gap-8 lg:grid-cols-3">
             {/* Map */}
           <div className="lg:col-span-2">
-              <Card className="overflow-hidden shadow-card relative" ref={mapContainerRef}>
+              <Card className={`overflow-hidden shadow-card relative ${isFullscreen ? "fixed inset-0 z-[9999] bg-white" : ""}`} ref={mapContainerRef}>
                 <CardContent className="p-0 h-full">
                   <div
                     ref={mapRef}
-                    className="h-[500px] w-full"
+                    className={`${isFullscreen ? "h-full" : "h-[500px]"} w-full`}
                     style={{ zIndex: 0 }}
                   />
                   {/* Geolocation button */}
@@ -510,15 +511,13 @@ const Map = () => {
                     )}
                   </Button>
                   {/* CSS Fullscreen toggle */}
-                  <MapFullscreenToggle
-                    mapContainerRef={mapContainerRef as React.RefObject<HTMLDivElement>}
-                    mapInstanceRef={mapInstanceRef}
-                    bgClass="bg-white"
-                    originalHeightClass="h-[500px]"
-                    mapDivRef={mapRef as React.RefObject<HTMLDivElement>}
+                  <MapFullscreenButtons
+                    isFullscreen={isFullscreen}
+                    onToggle={toggleFullscreen}
+                    onExit={exitFullscreen}
                   />
                 </CardContent>
-                {/* Legend - overlay in fullscreen via CSS, normal flow otherwise */}
+                {/* Legend */}
                 <div className="absolute bottom-2 left-2 z-[1000] flex flex-wrap gap-4 bg-white/90 backdrop-blur-sm rounded-lg px-3 py-1.5 shadow text-xs text-muted-foreground">
                   <div className="flex items-center gap-1.5">
                     <span className="w-3 h-3 rounded-full bg-green-600 border border-white shadow-sm" />


### PR DESCRIPTION
classList.add() was being overwritten by React re-renders, causing the map to disappear in fullscreen. Refactored to a useMapFullscreen hook that drives classes via React state in JSX conditionals.

https://claude.ai/code/session_015h6dPKqXiDRA9cubicPMx5