### PR TITLE
Fix CSV import: apnea level not updating due to header mapping mismatch

### DIFF
--- a/src/lib/csvImport.ts
+++ b/src/lib/csvImport.ts
@@ -93,6 +93,7 @@ const HEADER_MAP: Record<string, string> = {
   niveauapnee: "apnea_level",
   apnee: "apnea_level",
   apneelevel: "apnea_level",
+  apnealevel: "apnea_level",
   niveau: "apnea_level",
   genre: "gender",
   sexe: "gender",


### PR DESCRIPTION
The exported CSV uses "apnea_level" as header, which normalizes to "apnealevel", but only "apneelevel" (double e) was mapped. Added the missing mapping.