### PR TITLE
Fix Map page after merge

### DIFF
--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -486,11 +486,11 @@ const Map = () => {
           <div className="grid gap-8 lg:grid-cols-3">
             {/* Map */}
           <div className="lg:col-span-2">
-              <Card className={`overflow-hidden shadow-card relative ${isFullscreen ? "h-screen w-screen bg-background" : ""}`} ref={mapContainerRef}>
-                <CardContent className={`p-0 ${isFullscreen ? "h-full" : ""}`}>
+              <Card className="overflow-hidden shadow-card relative" ref={mapContainerRef}>
+                <CardContent className="p-0">
                   <div
                     ref={mapRef}
-                    className={`${isFullscreen ? "h-full" : "h-[75vh]"} w-full`}
+                    className="h-[75vh] w-full"
                     style={{ zIndex: 0 }}
                   />
                   {/* Geolocation button */}


### PR DESCRIPTION
## Summary
- Supprime les références à `isFullscreen` qui n'existait plus après le merge, causant un crash de la page Carte
- La carte reste à 75vh comme voulu

🤖 Generated with [Claude Code](https://claude.com/claude-code)