### PR TITLE
Fix 404 error when clicking 'Détails' on map popup

### DIFF
--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -429,7 +429,7 @@ const Map = () => {
             ${possStatusHtml}
             ${location.address ? `<p style="margin: 8px 0 0 0; font-size: 14px; color: #64748b;">${location.address}</p>` : ""}
             <div style="margin-top: 8px; display: flex; gap: 8px;">
-              <a href="/location/${location.id}" style="display: inline-flex; align-items: center; gap: 4px; color: #0ea5e9; text-decoration: none; font-size: 14px;">ℹ️ Détails</a>
+              <a id="detail-link-${location.id}" href="#" style="display: inline-flex; align-items: center; gap: 4px; color: #0ea5e9; text-decoration: none; font-size: 14px;">ℹ️ Détails</a>
               ${location.maps_url ? `<a href="${location.maps_url}" target="_blank" rel="noopener noreferrer" style="display: inline-flex; align-items: center; gap: 4px; color: #0ea5e9; text-decoration: none; font-size: 14px;">📍 Itinéraire</a>` : ""}
             </div>
             ${createOutingBtn}
@@ -439,8 +439,15 @@ const Map = () => {
         const popup = L.popup().setContent(popupContent);
         marker.bindPopup(popup);
 
-        // Add event listener for the create outing button
+        // Add event listeners for popup buttons
         marker.on('popupopen', () => {
+          const detailLink = document.getElementById(`detail-link-${location.id}`);
+          if (detailLink) {
+            detailLink.onclick = (e) => {
+              e.preventDefault();
+              navigate(`/location/${location.id}`);
+            };
+          }
           const btn = document.getElementById(`create-outing-${location.id}`);
           if (btn) {
             btn.onclick = () => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/((?!assets/).*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
The map popup used a raw <a href> for the detail link, causing a full
page navigation instead of client-side routing. This resulted in a 404
on Vercel since there was no SPA rewrite configuration.

- Changed detail link to use navigate() via click handler (same pattern
  as the existing "Organiser une sortie" button)
- Added vercel.json with SPA rewrites for direct URL access

https://claude.ai/code/session_0146pb7RZeZLEknbVRypUKGi