### PR TITLE
fix: center satellite and bathymetric maps on POI waypoints using fitBounds

### DIFF
--- a/src/components/locations/MarineMiniMap.tsx
+++ b/src/components/locations/MarineMiniMap.tsx
@@ -88,7 +88,7 @@ const MarineMiniMap = ({ latitude, longitude, siteName, siteId }: MarineMiniMapP
     }
   }, [latitude, longitude]);
 
-  // Add waypoint markers
+  // Add waypoint markers and fit bounds to show all POIs
   useEffect(() => {
     if (!mapInstanceRef.current) return;
 
@@ -105,14 +105,14 @@ const MarineMiniMap = ({ latitude, longitude, siteName, siteId }: MarineMiniMapP
       const color = getWaypointColor(waypoint.point_type);
       const label = getWaypointLabel(waypoint.point_type);
       const isDiveZone = waypoint.point_type === 'dive_zone';
-      const iconChar = waypoint.point_type === 'parking' ? 'P' 
-        : waypoint.point_type === 'water_entry' ? '↓' 
-        : waypoint.point_type === 'water_exit' ? '✚' 
+      const iconChar = waypoint.point_type === 'parking' ? 'P'
+        : waypoint.point_type === 'water_entry' ? '↓'
+        : waypoint.point_type === 'water_exit' ? '✚'
         : waypoint.point_type === 'dive_zone' ? '🤿'
         : '●';
 
       const waypointIcon = L.divIcon({
-        html: isDiveZone 
+        html: isDiveZone
           ? `<div style="
               background: rgba(14, 165, 233, 0.4);
               width: 32px;
@@ -147,11 +147,19 @@ const MarineMiniMap = ({ latitude, longitude, siteName, siteId }: MarineMiniMapP
 
       const marker = L.marker([waypoint.latitude, waypoint.longitude], { icon: waypointIcon })
         .addTo(mapInstanceRef.current!);
-      
+
       marker.bindPopup(`<strong>${label}</strong><br/>${waypoint.name}`);
       waypointMarkersRef.current.push(marker);
     });
-  }, [waypoints]);
+
+    // Fit bounds to show all waypoints + site location
+    const allPoints: [number, number][] = [
+      [latitude, longitude],
+      ...waypoints.map((wp: Waypoint) => [wp.latitude, wp.longitude] as [number, number]),
+    ];
+    const bounds = L.latLngBounds(allPoints);
+    mapInstanceRef.current.fitBounds(bounds, { padding: [40, 40], maxZoom: 16 });
+  }, [waypoints, latitude, longitude]);
 
   return (
     <div

--- a/src/components/locations/SatelliteMiniMap.tsx
+++ b/src/components/locations/SatelliteMiniMap.tsx
@@ -85,7 +85,7 @@ const SatelliteMiniMap = ({ latitude, longitude, siteName, siteId }: SatelliteMi
     }
   }, [latitude, longitude]);
 
-  // Add waypoint markers
+  // Add waypoint markers and fit bounds to show all POIs
   useEffect(() => {
     if (!mapInstanceRef.current) return;
 
@@ -148,7 +148,15 @@ const SatelliteMiniMap = ({ latitude, longitude, siteName, siteId }: SatelliteMi
       marker.bindPopup(`<strong>${label}</strong><br/>${waypoint.name}`);
       waypointMarkersRef.current.push(marker);
     });
-  }, [waypoints]);
+
+    // Fit bounds to show all waypoints + site location
+    const allPoints: [number, number][] = [
+      [latitude, longitude],
+      ...waypoints.map((wp: Waypoint) => [wp.latitude, wp.longitude] as [number, number]),
+    ];
+    const bounds = L.latLngBounds(allPoints);
+    mapInstanceRef.current.fitBounds(bounds, { padding: [40, 40], maxZoom: 16 });
+  }, [waypoints, latitude, longitude]);
 
   return (
     <div


### PR DESCRIPTION
Both SatelliteMiniMap and MarineMiniMap used a fixed southward offset for
centering, which meant waypoints/POIs were often not visible in the initial
view. Now when waypoints are loaded, the maps use fitBounds to automatically
adjust the viewport to include all waypoints plus the site location, with
padding and a max zoom of 16.

https://claude.ai/code/session_01G5X5xVhdNvKNmBVpfSQSPt