### PR TITLE
Gestion saisonnière des adhérents

### DIFF
--- a/src/hooks/useMembershipYearlyStatus.ts
+++ b/src/hooks/useMembershipYearlyStatus.ts
@@ -175,11 +175,44 @@ export const useMembershipYearlyStatus = (seasonYear: number) => {
     },
   });
 
+  // Delete status for a single member for the current season
+  const deleteMemberStatus = useMutation({
+    mutationFn: async (memberId: string) => {
+      const { error } = await supabase
+        .from("membership_yearly_status")
+        .delete()
+        .eq("member_id", memberId)
+        .eq("season_year", seasonYear);
+
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["membership-yearly-status", seasonYear] });
+    },
+  });
+
+  // Delete all statuses for the current season
+  const deleteAllStatusForSeason = useMutation({
+    mutationFn: async () => {
+      const { error } = await supabase
+        .from("membership_yearly_status")
+        .delete()
+        .eq("season_year", seasonYear);
+
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["membership-yearly-status", seasonYear] });
+    },
+  });
+
   return {
     statuses,
     isLoading,
     getStatusForMember,
     upsertStatus,
     upsertStatusBatch,
+    deleteMemberStatus,
+    deleteAllStatusForSeason,
   };
 };


### PR DESCRIPTION
## Summary
- Ajout bouton "Purger la saison" pour supprimer tous les statuts d'une saison en masse
- Le bouton corbeille par adhérent supprime désormais les données saisonnières (et non l'adhérent entier)
- Filtrage des adhérents : seuls ceux ayant un statut pour la saison affichée sont visibles (les anciens adhérents n'apparaissent plus sur les nouvelles saisons)

## Test plan
- [ ] Vérifier que le bouton "Purger la saison" apparaît et supprime tous les statuts de la saison sélectionnée
- [ ] Vérifier que le bouton corbeille par ligne supprime uniquement les données saisonnières
- [ ] Vérifier qu'un adhérent sans statut pour la saison affichée n'apparaît pas dans la liste
- [ ] Vérifier que l'import CSV crée bien les statuts et que les adhérents importés apparaissent
- [ ] Vérifier que les données des autres saisons ne sont pas impactées

🤖 Generated with [Claude Code](https://claude.com/claude-code)