### PR TITLE
Fix stats saison et formulaire adhérent

### DIFF
--- a/src/components/admin/ClubMembersDirectory.tsx
+++ b/src/components/admin/ClubMembersDirectory.tsx
@@ -262,19 +262,29 @@ const ClubMembersDirectory = () => {
 
     try {
       let memberId: string;
-      
+
+      // Convert empty strings to null for optional fields
+      const cleanedData = {
+        ...formData,
+        email: formData.email.toLowerCase(),
+        phone: formData.phone || null,
+        birth_date: formData.birth_date || null,
+        address: formData.address || null,
+        joined_at: formData.joined_at || null,
+        emergency_contact_name: formData.emergency_contact_name || null,
+        emergency_contact_phone: formData.emergency_contact_phone || null,
+        gender: formData.gender || null,
+        notes: formData.notes || null,
+      };
+
       if (editingMember) {
         await updateMember.mutateAsync({
           id: editingMember.id,
-          ...formData,
-          email: formData.email.toLowerCase(),
+          ...cleanedData,
         });
         memberId = editingMember.id;
       } else {
-        const result = await createMember.mutateAsync({
-          ...formData,
-          email: formData.email.toLowerCase(),
-        });
+        const result = await createMember.mutateAsync(cleanedData);
         memberId = result.id;
       }
 


### PR DESCRIPTION
## Summary
- Fix stats bar : les compteurs (adhérents, encadrants, dossiers complets, incomplets, inscrits app) sont maintenant basés sur les adhérents de la saison sélectionnée
- Fix formulaire : les champs optionnels vides (dates, téléphone, adresse) sont convertis en `null` avant envoi à Supabase, corrigeant le bug où le formulaire ne se fermait pas

## Test plan
- [ ] Vérifier que les compteurs correspondent aux adhérents de la saison affichée
- [ ] Vérifier qu'on peut modifier un adhérent sans date d'inscription et que le formulaire se ferme correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)