### PR TITLE
feat: trigger DB sync member_status encadrant à la création de profil

### DIFF
--- a/src/components/admin/ClubMembersDirectory.tsx
+++ b/src/components/admin/ClubMembersDirectory.tsx
@@ -83,6 +83,7 @@ import {
   MembershipYearlyStatus
 } from "@/hooks/useMembershipYearlyStatus";
 import { useApneaLevels } from "@/hooks/useApneaLevels";
+import { supabase } from "@/integrations/supabase/client";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { cn } from "@/lib/utils";
@@ -297,7 +298,15 @@ const ClubMembersDirectory = () => {
           is_encadrant: seasonalFormData.is_encadrant,
         },
       });
-      
+
+      // Sync profiles.member_status so the encadrant badge appears everywhere in the app
+      if (formData.email) {
+        await supabase
+          .from("profiles")
+          .update({ member_status: seasonalFormData.is_encadrant ? "Encadrant" : "Membre" })
+          .eq("email", formData.email.toLowerCase());
+      }
+
       setIsFormOpen(false);
       resetForm();
     } catch (error) {

--- a/src/components/admin/ClubMembersDirectory.tsx
+++ b/src/components/admin/ClubMembersDirectory.tsx
@@ -1256,19 +1256,39 @@ const ClubMembersDirectory = () => {
                   />
                 </div>
               </div>
-              <div className="flex items-center gap-3 p-3 rounded-lg bg-primary/5 border border-primary/20">
-                <Checkbox
-                  id="is_encadrant"
-                  checked={seasonalFormData.is_encadrant ?? false}
-                  onCheckedChange={(checked) => setSeasonalFormData({ ...seasonalFormData, is_encadrant: !!checked })}
-                />
-                <Label htmlFor="is_encadrant" className="text-sm font-medium cursor-pointer">
-                  🤿 Est Encadrant ({getSeasonLabel(selectedSeason)})
-                  <span className="block text-xs text-muted-foreground font-normal">
-                    Cette personne encadre les sorties et a accès aux outils d'organisation
-                  </span>
-                </Label>
-              </div>
+              {(() => {
+                const currentLevelInfo = apneaLevels?.find(l => l.code === seasonalFormData.apnea_level);
+                const hasInstructorDiploma = currentLevelInfo?.is_instructor ?? false;
+                const warnNoLevel = (seasonalFormData.is_encadrant ?? false) && !hasInstructorDiploma;
+                return (
+                  <div className={`p-3 rounded-lg border ${warnNoLevel ? "bg-orange-50 border-orange-300 dark:bg-orange-950/20 dark:border-orange-700" : "bg-primary/5 border-primary/20"}`}>
+                    <div className="flex items-center gap-3">
+                      <Checkbox
+                        id="is_encadrant"
+                        checked={seasonalFormData.is_encadrant ?? false}
+                        onCheckedChange={(checked) => {
+                          if (checked && !hasInstructorDiploma) {
+                            toast.warning("Attention : ce membre n'a pas de diplôme d'encadrant reconnu. Vérifiez son niveau apnée avant de valider.");
+                          }
+                          setSeasonalFormData({ ...seasonalFormData, is_encadrant: !!checked });
+                        }}
+                      />
+                      <Label htmlFor="is_encadrant" className="text-sm font-medium cursor-pointer">
+                        🤿 Est Encadrant ({getSeasonLabel(selectedSeason)})
+                        <span className="block text-xs text-muted-foreground font-normal">
+                          Cette personne encadre les sorties et a accès aux outils d'organisation
+                        </span>
+                      </Label>
+                    </div>
+                    {warnNoLevel && (
+                      <p className="mt-2 text-xs text-orange-700 dark:text-orange-400 flex items-center gap-1">
+                        <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                        Aucun diplôme d'encadrant détecté pour le niveau «&nbsp;{seasonalFormData.apnea_level || "non renseigné"}&nbsp;». Vérifiez le niveau apnée.
+                      </p>
+                    )}
+                  </div>
+                );
+              })()}
               <div>
                 <Label htmlFor="notes">Notes</Label>
                 <Textarea

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -255,17 +255,19 @@ const OutingDetail = () => {
     (apneaLevels || []).map(l => [l.code, l])
   );
 
-  // Sort participants: organizer first, then instructors, then others
+  // Sort participants: organizer first, then instructors (by member_status OR apnea level), then others
+  const isReservationEncadrant = (r: typeof confirmedReservations[number]) => {
+    if (r.profile?.member_status === "Encadrant") return true;
+    const li = apneaLevelMap.get(r.profile?.apnea_level ?? "");
+    return li?.is_instructor ?? false;
+  };
   const sortedConfirmed = [...confirmedReservations].sort((a, b) => {
     const aIsOrganizer = a.user_id === outing.organizer_id;
     const bIsOrganizer = b.user_id === outing.organizer_id;
     if (aIsOrganizer && !bIsOrganizer) return -1;
     if (!aIsOrganizer && bIsOrganizer) return 1;
-
-    const aLevel = apneaLevelMap.get(a.profile?.apnea_level ?? "");
-    const bLevel = apneaLevelMap.get(b.profile?.apnea_level ?? "");
-    const aIsInstructor = aLevel?.is_instructor ?? false;
-    const bIsInstructor = bLevel?.is_instructor ?? false;
+    const aIsInstructor = isReservationEncadrant(a);
+    const bIsInstructor = isReservationEncadrant(b);
     if (aIsInstructor && !bIsInstructor) return -1;
     if (!aIsInstructor && bIsInstructor) return 1;
     return 0;
@@ -536,111 +538,167 @@ const OutingDetail = () => {
           )}
 
           {/* 2. Participants - enriched with instructor icons, organizer highlighted, apnea levels & depth */}
+          {(() => {
+            // A person is an encadrant if their member_status = 'Encadrant' (admin-controlled, always up to date)
+            // OR if their apnea level is flagged as instructor in the apnea_levels table.
+            const isEncadrant = (r: typeof sortedConfirmed[number]) => {
+              if (r.profile?.member_status === "Encadrant") return true;
+              const li = apneaLevelMap.get(r.profile?.apnea_level ?? "");
+              return li?.is_instructor ?? false;
+            };
+
+            // Separate confirmed reservations into instructors and regular participants
+            const confirmedInstructors = sortedConfirmed.filter(isEncadrant);
+            const confirmedParticipants = sortedConfirmed.filter(r => !isEncadrant(r));
+
+            // Effective max = sum of each instructor's max_participants_encadrement
+            const effectiveMax = confirmedInstructors.length > 0
+              ? confirmedInstructors.reduce((sum, r) => {
+                  const li = apneaLevelMap.get(r.profile?.apnea_level ?? "");
+                  return sum + (li?.max_participants_encadrement ?? outing.max_participants);
+                }, 0)
+              : outing.max_participants;
+
+            const renderRow = (reservation: typeof sortedConfirmed[number]) => {
+              const profile = reservation.profile;
+              const initials = profile ? `${profile.first_name?.[0] ?? ""}${profile.last_name?.[0] ?? ""}` : "?";
+              const isOrg = reservation.user_id === outing.organizer_id;
+              const levelInfo = apneaLevelMap.get(profile?.apnea_level ?? "");
+              const isInstructor = isEncadrant(reservation);
+              const depth = !isInstructor ? extractDepth(levelInfo?.prerogatives ?? null) : null;
+              return (
+                <div
+                  key={reservation.id}
+                  className={`flex items-center justify-between rounded-lg border p-3 ${
+                    isOrg
+                      ? "border-amber-300 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-700"
+                      : isInstructor
+                        ? "border-blue-200 bg-blue-50/60 dark:bg-blue-950/20 dark:border-blue-700"
+                        : "border-border bg-muted/30"
+                  }`}
+                >
+                  <div className="flex items-center gap-3">
+                    <button
+                      type="button"
+                      className="relative focus:outline-none"
+                      onClick={() => profile && setSelectedContact({
+                        firstName: profile.first_name ?? "",
+                        lastName: profile.last_name ?? "",
+                        avatarUrl: profile.avatar_url ?? null,
+                        email: profile.email ?? null,
+                        phone: participantPhones?.get((profile.email ?? "").toLowerCase()) ?? null,
+                      })}
+                    >
+                      <Avatar className="h-10 w-10 transition-opacity hover:opacity-80">
+                        <AvatarImage src={profile?.avatar_url ?? undefined} />
+                        <AvatarFallback className={`text-sm ${isOrg ? "bg-amber-200 text-amber-800" : isInstructor ? "bg-blue-100 text-blue-800" : "bg-primary/10 text-primary"}`}>
+                          {initials}
+                        </AvatarFallback>
+                      </Avatar>
+                      {isInstructor && (
+                        <div className="absolute -bottom-1 -right-1 h-5 w-5 rounded-full bg-amber-500 flex items-center justify-center shadow-sm" title="Encadrant">
+                          <Shield className="h-3 w-3 text-white" />
+                        </div>
+                      )}
+                    </button>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <p className="font-medium text-foreground">
+                          {profile?.first_name} {profile?.last_name}
+                        </p>
+                        {isOrg && (
+                          <Badge className="bg-amber-500 text-white text-[10px] px-1.5 py-0">Organisateur</Badge>
+                        )}
+                        {isInstructor && !isOrg && (
+                          <Badge className="bg-blue-500 text-white text-[10px] px-1.5 py-0">Encadrant</Badge>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+                        {profile?.apnea_level && (
+                          <Badge variant={isInstructor ? "default" : "outline"} className={`text-xs ${isInstructor ? "bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-900/40 dark:text-amber-300" : ""}`}>
+                            {profile.apnea_level}
+                          </Badge>
+                        )}
+                        {depth && (
+                          <span className="text-xs text-muted-foreground flex items-center gap-0.5">
+                            <ArrowDown className="h-3 w-3" />
+                            {depth}
+                          </span>
+                        )}
+                        {reservation.carpool_option === "driver" && (
+                          <Badge variant="secondary" className="text-xs gap-1">
+                            <Car className="h-3 w-3" /> {reservation.carpool_seats} places
+                          </Badge>
+                        )}
+                        {reservation.carpool_option === "passenger" && (
+                          <Badge variant="outline" className="text-xs">Cherche covoit.</Badge>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  {canMarkAttendance && canEditPresenceAndReport && (
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        checked={reservation.is_present}
+                        onCheckedChange={(checked) =>
+                          updatePresence.mutate({ reservationId: reservation.id, isPresent: !!checked })
+                        }
+                      />
+                      <span className="text-sm text-muted-foreground">Présent</span>
+                    </div>
+                  )}
+                  {canMarkAttendance && !canEditPresenceAndReport && (
+                    <Badge variant={reservation.is_present ? "default" : "outline"} className="text-xs">
+                      {reservation.is_present ? "Présent" : "Absent"}
+                    </Badge>
+                  )}
+                </div>
+              );
+            };
+
+            return (
           <Card className="shadow-card my-6">
             <CardHeader>
-              <CardTitle className="flex items-center gap-2">
+              <CardTitle className="flex items-center gap-2 flex-wrap">
                 <Users className="h-5 w-5 text-primary" />
-                Participants confirmés ({confirmedReservations.length}/{outing.max_participants})
+                Participants confirmés ({confirmedReservations.length}/{effectiveMax})
+                {confirmedInstructors.length >= 2 && (
+                  <Badge className="text-xs bg-blue-100 text-blue-800 border-blue-300 dark:bg-blue-900/40 dark:text-blue-300">
+                    {confirmedInstructors.length} encadrants · capacité ×{confirmedInstructors.length}
+                  </Badge>
+                )}
               </CardTitle>
             </CardHeader>
             <CardContent>
               {sortedConfirmed.length === 0 ? (
                 <p className="text-center text-muted-foreground py-4">Aucun inscrit</p>
               ) : (
-                <div className="space-y-2">
-                  {sortedConfirmed.map((reservation) => {
-                    const profile = reservation.profile;
-                    const initials = profile ? `${profile.first_name?.[0] ?? ""}${profile.last_name?.[0] ?? ""}` : "?";
-                    const isOrg = reservation.user_id === outing.organizer_id;
-                    const levelInfo = apneaLevelMap.get(profile?.apnea_level ?? "");
-                    const isInstructor = levelInfo?.is_instructor ?? false;
-                    const depth = !isInstructor ? extractDepth(levelInfo?.prerogatives ?? null) : null;
-
-                    return (
-                      <div
-                        key={reservation.id}
-                        className={`flex items-center justify-between rounded-lg border p-3 ${
-                          isOrg
-                            ? "border-amber-300 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-700"
-                            : "border-border bg-muted/30"
-                        }`}
-                      >
-                        <div className="flex items-center gap-3">
-                          <button
-                            type="button"
-                            className="relative focus:outline-none"
-                            onClick={() => profile && setSelectedContact({
-                              firstName: profile.first_name ?? "",
-                              lastName: profile.last_name ?? "",
-                              avatarUrl: profile.avatar_url ?? null,
-                              email: profile.email ?? null,
-                              phone: participantPhones?.get((profile.email ?? "").toLowerCase()) ?? null,
-                            })}
-                          >
-                            <Avatar className="h-10 w-10 transition-opacity hover:opacity-80">
-                              <AvatarImage src={profile?.avatar_url ?? undefined} />
-                              <AvatarFallback className={`text-sm ${isOrg ? "bg-amber-200 text-amber-800" : "bg-primary/10 text-primary"}`}>
-                                {initials}
-                              </AvatarFallback>
-                            </Avatar>
-                            {isInstructor && (
-                              <div className="absolute -bottom-1 -right-1 h-5 w-5 rounded-full bg-amber-500 flex items-center justify-center shadow-sm" title="Encadrant">
-                                <Shield className="h-3 w-3 text-white" />
-                              </div>
-                            )}
-                          </button>
-                          <div>
-                            <div className="flex items-center gap-2">
-                              <p className="font-medium text-foreground">
-                                {profile?.first_name} {profile?.last_name}
-                              </p>
-                              {isOrg && (
-                                <Badge className="bg-amber-500 text-white text-[10px] px-1.5 py-0">Organisateur</Badge>
-                              )}
-                            </div>
-                            <div className="flex items-center gap-2 mt-0.5 flex-wrap">
-                              {profile?.apnea_level && (
-                                <Badge variant={isInstructor ? "default" : "outline"} className={`text-xs ${isInstructor ? "bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-900/40 dark:text-amber-300" : ""}`}>
-                                  {profile.apnea_level}
-                                </Badge>
-                              )}
-                              {depth && (
-                                <span className="text-xs text-muted-foreground flex items-center gap-0.5">
-                                  <ArrowDown className="h-3 w-3" />
-                                  {depth}
-                                </span>
-                              )}
-                              {reservation.carpool_option === "driver" && (
-                                <Badge variant="secondary" className="text-xs gap-1">
-                                  <Car className="h-3 w-3" /> {reservation.carpool_seats} places
-                                </Badge>
-                              )}
-                              {reservation.carpool_option === "passenger" && (
-                                <Badge variant="outline" className="text-xs">Cherche covoit.</Badge>
-                              )}
-                            </div>
-                          </div>
-                        </div>
-
-                        {canMarkAttendance && canEditPresenceAndReport && (
-                          <div className="flex items-center gap-2">
-                            <Checkbox
-                              checked={reservation.is_present}
-                              onCheckedChange={(checked) =>
-                                updatePresence.mutate({ reservationId: reservation.id, isPresent: !!checked })
-                              }
-                            />
-                            <span className="text-sm text-muted-foreground">Présent</span>
-                          </div>
-                        )}
-                        {canMarkAttendance && !canEditPresenceAndReport && (
-                          <Badge variant={reservation.is_present ? "default" : "outline"} className="text-xs">
-                            {reservation.is_present ? "Présent" : "Absent"}
-                          </Badge>
-                        )}
+                <div className="space-y-3">
+                  {confirmedInstructors.length > 0 && (
+                    <>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 flex items-center gap-1.5 px-1">
+                        <Shield className="h-3.5 w-3.5" />
+                        Encadrant{confirmedInstructors.length > 1 ? "s" : ""} ({confirmedInstructors.length})
+                      </p>
+                      <div className="space-y-2">
+                        {confirmedInstructors.map(renderRow)}
                       </div>
-                    );
-                  })}
+                    </>
+                  )}
+                  {confirmedParticipants.length > 0 && (
+                    <>
+                      {confirmedInstructors.length > 0 && (
+                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground flex items-center gap-1.5 px-1 pt-1">
+                          <Users className="h-3.5 w-3.5" />
+                          Participants ({confirmedParticipants.length})
+                        </p>
+                      )}
+                      <div className="space-y-2">
+                        {confirmedParticipants.map(renderRow)}
+                      </div>
+                    </>
+                  )}
                 </div>
               )}
 
@@ -689,6 +747,8 @@ const OutingDetail = () => {
               )}
             </CardContent>
           </Card>
+            );
+          })()}
 
           {/* 3. Carpool Section - full width */}
           <CarpoolSection

--- a/supabase/migrations/20260324100000_sync_member_status_on_profile_insert.sql
+++ b/supabase/migrations/20260324100000_sync_member_status_on_profile_insert.sql
@@ -1,0 +1,40 @@
+-- Trigger: quand un nouveau profil est créé, synchroniser member_status
+-- depuis membership_yearly_status si la personne est encadrante
+
+CREATE OR REPLACE FUNCTION public.sync_member_status_on_profile_insert()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_is_encadrant boolean;
+BEGIN
+  -- Chercher si cette adresse email est marquée encadrante dans la saison courante
+  SELECT COALESCE(mys.is_encadrant, false) INTO v_is_encadrant
+  FROM club_members_directory cmd
+  JOIN membership_yearly_status mys ON mys.member_id = cmd.id
+  WHERE lower(cmd.email) = lower(NEW.email)
+    AND mys.season_year = (
+      CASE WHEN EXTRACT(MONTH FROM now()) >= 9
+        THEN EXTRACT(YEAR FROM now())::int + 1
+        ELSE EXTRACT(YEAR FROM now())::int
+      END
+    )
+  LIMIT 1;
+
+  -- Si encadrant, mettre à jour member_status
+  IF v_is_encadrant THEN
+    NEW.member_status := 'Encadrant';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Attacher le trigger sur INSERT dans profiles
+DROP TRIGGER IF EXISTS trg_sync_member_status_on_insert ON public.profiles;
+CREATE TRIGGER trg_sync_member_status_on_insert
+  BEFORE INSERT ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_member_status_on_profile_insert();


### PR DESCRIPTION
## Summary
- Nouveau trigger `trg_sync_member_status_on_insert` sur la table `profiles`
- Quand Astrid, Julian, Geoffrey (ou tout futur encadrant) créent leur compte app, leur `member_status` est automatiquement mis à `'Encadrant'` si leur email est marqué `is_encadrant = true` dans la saison courante

## Test plan
- [ ] Créer un compte app avec l'email d'un encadrant connu dans le directory → vérifier que `profiles.member_status = 'Encadrant'`
- [ ] Créer un compte app avec un email non-encadrant → `member_status = 'Membre'` (défaut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)