### PR TITLE
feat: synthèse matériel par encadrant

### DIFF
--- a/src/components/equipment/EquipmentSynthesisByEncadrant.tsx
+++ b/src/components/equipment/EquipmentSynthesisByEncadrant.tsx
@@ -1,0 +1,194 @@
+import { Shield } from "lucide-react";
+import { EquipmentInventoryItem } from "@/hooks/useEquipment";
+
+interface EquipmentSynthesisByEncadrantProps {
+  inventory: EquipmentInventoryItem[];
+}
+
+const ACTIVE_STATUSES = new Set(["disponible", "prêté"]);
+
+const formatCurrency = (value: number): string =>
+  new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+
+const matchesColumn = (name: string, column: string): boolean => {
+  const n = name.toLowerCase();
+  switch (column) {
+    case "planche":
+      return n.includes("planche");
+    case "bouee":
+      return n.includes("bouée") || n.includes("bouee");
+    case "kit":
+      return n.includes("kit");
+    case "telephone":
+      return n.includes("téléphone") || n.includes("telephone");
+    default:
+      return false;
+  }
+};
+
+const COLUMNS = ["planche", "bouee", "kit", "telephone"] as const;
+type Column = (typeof COLUMNS)[number];
+
+const COLUMN_LABELS: Record<Column, string> = {
+  planche: "Planche",
+  bouee: "Bouée ronde",
+  kit: "Kit oxy",
+  telephone: "Téléphone",
+};
+
+interface EncadrantRow {
+  id: string;
+  name: string;
+  counts: Record<Column | "autres", number>;
+  valo: number;
+}
+
+export const EquipmentSynthesisByEncadrant = ({
+  inventory,
+}: EquipmentSynthesisByEncadrantProps) => {
+  // Build rows grouped by owner, only active items
+  const rowMap = new Map<string, EncadrantRow>();
+
+  for (const item of inventory) {
+    if (!ACTIVE_STATUSES.has(item.status)) continue;
+    if (!item.owner) continue;
+
+    const ownerId = item.owner.id;
+    if (!rowMap.has(ownerId)) {
+      rowMap.set(ownerId, {
+        id: ownerId,
+        name: `${item.owner.first_name} ${item.owner.last_name}`,
+        counts: { planche: 0, bouee: 0, kit: 0, telephone: 0, autres: 0 },
+        valo: 0,
+      });
+    }
+
+    const row = rowMap.get(ownerId)!;
+    const catalogName = item.catalog?.name || "";
+    const unitValue = item.catalog?.estimated_value || 0;
+
+    row.valo += unitValue;
+
+    let matched = false;
+    for (const col of COLUMNS) {
+      if (matchesColumn(catalogName, col)) {
+        row.counts[col]++;
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      row.counts.autres++;
+    }
+  }
+
+  const rows = Array.from(rowMap.values()).sort((a, b) =>
+    a.name.localeCompare(b.name, "fr")
+  );
+
+  if (rows.length === 0) {
+    return (
+      <div className="text-center text-muted-foreground py-8">
+        Aucun matériel actif dans l'inventaire
+      </div>
+    );
+  }
+
+  // Totals row
+  const totals = rows.reduce(
+    (acc, row) => {
+      for (const col of COLUMNS) acc.counts[col] += row.counts[col];
+      acc.counts.autres += row.counts.autres;
+      acc.valo += row.valo;
+      return acc;
+    },
+    { counts: { planche: 0, bouee: 0, kit: 0, telephone: 0, autres: 0 }, valo: 0 }
+  );
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border">
+            <th className="text-left py-2 pr-4 font-semibold text-foreground">
+              Encadrant
+            </th>
+            {COLUMNS.map((col) => (
+              <th
+                key={col}
+                className="text-center py-2 px-3 font-semibold text-foreground whitespace-nowrap"
+              >
+                {COLUMN_LABELS[col]}
+              </th>
+            ))}
+            <th className="text-center py-2 px-3 font-semibold text-foreground">
+              Autres
+            </th>
+            <th className="text-right py-2 pl-4 font-semibold text-foreground whitespace-nowrap">
+              Valo totale
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.id}
+              className="border-b border-border/50 hover:bg-muted/30 transition-colors"
+            >
+              <td className="py-2.5 pr-4 font-medium text-foreground">
+                <span className="flex items-center gap-1.5">
+                  <Shield className="h-3.5 w-3.5 text-amber-500 shrink-0" />
+                  {row.name}
+                </span>
+              </td>
+              {COLUMNS.map((col) => (
+                <td key={col} className="text-center py-2.5 px-3">
+                  {row.counts[col] > 0 ? (
+                    <span className="font-medium text-foreground">
+                      {row.counts[col]}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground/40">—</span>
+                  )}
+                </td>
+              ))}
+              <td className="text-center py-2.5 px-3">
+                {row.counts.autres > 0 ? (
+                  <span className="font-medium text-foreground">
+                    {row.counts.autres}
+                  </span>
+                ) : (
+                  <span className="text-muted-foreground/40">—</span>
+                )}
+              </td>
+              <td className="text-right py-2.5 pl-4 font-semibold text-primary whitespace-nowrap">
+                {row.valo > 0 ? formatCurrency(row.valo) : "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr className="border-t-2 border-border bg-muted/20">
+            <td className="py-2.5 pr-4 font-bold text-foreground">Total</td>
+            {COLUMNS.map((col) => (
+              <td key={col} className="text-center py-2.5 px-3 font-bold text-foreground">
+                {totals.counts[col] || "—"}
+              </td>
+            ))}
+            <td className="text-center py-2.5 px-3 font-bold text-foreground">
+              {totals.counts.autres || "—"}
+            </td>
+            <td className="text-right py-2.5 pl-4 font-bold text-primary whitespace-nowrap">
+              {formatCurrency(totals.valo)}
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  );
+};

--- a/src/components/equipment/EquipmentSynthesisByEncadrant.tsx
+++ b/src/components/equipment/EquipmentSynthesisByEncadrant.tsx
@@ -1,8 +1,15 @@
 import { Shield } from "lucide-react";
 import { EquipmentInventoryItem } from "@/hooks/useEquipment";
 
+interface Encadrant {
+  id: string;
+  first_name: string;
+  last_name: string;
+}
+
 interface EquipmentSynthesisByEncadrantProps {
   inventory: EquipmentInventoryItem[];
+  encadrants: Encadrant[];
 }
 
 const ACTIVE_STATUSES = new Set(["disponible", "prêté"]);
@@ -50,15 +57,26 @@ interface EncadrantRow {
 
 export const EquipmentSynthesisByEncadrant = ({
   inventory,
+  encadrants,
 }: EquipmentSynthesisByEncadrantProps) => {
-  // Build rows grouped by owner, only active items
+  // Seed rowMap with all encadrants (even those with no inventory)
   const rowMap = new Map<string, EncadrantRow>();
+  for (const enc of encadrants) {
+    rowMap.set(enc.id, {
+      id: enc.id,
+      name: `${enc.first_name} ${enc.last_name}`,
+      counts: { planche: 0, bouee: 0, kit: 0, telephone: 0, autres: 0 },
+      valo: 0,
+    });
+  }
 
+  // Fill counts from inventory (active items only)
   for (const item of inventory) {
     if (!ACTIVE_STATUSES.has(item.status)) continue;
     if (!item.owner) continue;
 
     const ownerId = item.owner.id;
+    // If owner is not in encadrants list, add them anyway
     if (!rowMap.has(ownerId)) {
       rowMap.set(ownerId, {
         id: ownerId,
@@ -88,7 +106,7 @@ export const EquipmentSynthesisByEncadrant = ({
   }
 
   const rows = Array.from(rowMap.values()).sort((a, b) =>
-    a.name.localeCompare(b.name, "fr")
+    b.valo - a.valo || a.name.localeCompare(b.name, "fr")
   );
 
   if (rows.length === 0) {

--- a/src/components/participants/ParticipantsList.tsx
+++ b/src/components/participants/ParticipantsList.tsx
@@ -1,3 +1,4 @@
+import { Shield, Users } from "lucide-react";
 import ParticipantAvatar from "./ParticipantAvatar";
 
 interface Participant {
@@ -46,25 +47,58 @@ const ParticipantsList = ({
   const remainingCount = participants.length - maxVisible;
 
   if (showNames) {
+    const encadrants = visibleParticipants.filter(
+      p => p.member_status === "Encadrant" || (organizerId && p.id === organizerId)
+    );
+    const regularParticipants = visibleParticipants.filter(
+      p => p.member_status !== "Encadrant" && !(organizerId && p.id === organizerId)
+    );
+    const hasGroups = encadrants.length > 0 && regularParticipants.length > 0;
+
+    const renderAvatar = (participant: Participant) => (
+      <div key={participant.id} className="flex flex-col items-center gap-1">
+        <ParticipantAvatar
+          firstName={participant.first_name}
+          lastName={participant.last_name}
+          avatarUrl={participant.avatar_url}
+          memberStatus={participant.member_status}
+          isOrganizer={organizerId ? participant.id === organizerId : false}
+          size={size}
+        />
+        <span className="text-xs text-muted-foreground text-center max-w-[60px] truncate">
+          {participant.first_name}
+        </span>
+      </div>
+    );
+
     return (
       <div className="space-y-2">
-        <div className="flex flex-wrap gap-3">
-          {visibleParticipants.map((participant) => (
-            <div key={participant.id} className="flex flex-col items-center gap-1">
-              <ParticipantAvatar
-                firstName={participant.first_name}
-                lastName={participant.last_name}
-                avatarUrl={participant.avatar_url}
-                memberStatus={participant.member_status}
-                isOrganizer={organizerId ? participant.id === organizerId : false}
-                size={size}
-              />
-              <span className="text-xs text-muted-foreground text-center max-w-[60px] truncate">
-                {participant.first_name}
-              </span>
+        {hasGroups ? (
+          <>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-amber-600 flex items-center gap-1 mb-1.5">
+                <Shield className="h-3 w-3" />
+                Encadrant{encadrants.length > 1 ? "s" : ""}
+              </p>
+              <div className="flex flex-wrap gap-3">
+                {encadrants.map(renderAvatar)}
+              </div>
             </div>
-          ))}
-        </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground flex items-center gap-1 mb-1.5">
+                <Users className="h-3 w-3" />
+                Participants
+              </p>
+              <div className="flex flex-wrap gap-3">
+                {regularParticipants.map(renderAvatar)}
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="flex flex-wrap gap-3">
+            {visibleParticipants.map(renderAvatar)}
+          </div>
+        )}
         {remainingCount > 0 && (
           <p className="text-xs text-muted-foreground">
             +{remainingCount} autres participants

--- a/src/pages/Equipment.tsx
+++ b/src/pages/Equipment.tsx
@@ -648,6 +648,7 @@ const InventoryItemCard = ({ item, showActions = false }: { item: EquipmentInven
 
 const GlobalInventoryTab = () => {
   const { data: inventory, isLoading } = useGlobalEquipmentInventory();
+  const { data: encadrants } = useEncadrants();
   const [subTab, setSubTab] = useState<"synthesis" | "list" | "by-encadrant">("synthesis");
   const [ownerFilter, setOwnerFilter] = useState<string>("all");
 
@@ -752,7 +753,7 @@ const GlobalInventoryTab = () => {
                 <Loader2 className="h-6 w-6 animate-spin text-primary" />
               </div>
             ) : (
-              <EquipmentSynthesisByEncadrant inventory={inventory || []} />
+              <EquipmentSynthesisByEncadrant inventory={inventory || []} encadrants={encadrants || []} />
             )}
           </TabsContent>
 

--- a/src/pages/Equipment.tsx
+++ b/src/pages/Equipment.tsx
@@ -31,6 +31,7 @@ import { fr } from "date-fns/locale";
 import { toast } from "sonner";
 import { EquipmentDetailSheet } from "@/components/equipment/EquipmentDetailSheet";
 import { EquipmentSynthesis } from "@/components/equipment/EquipmentSynthesis";
+import { EquipmentSynthesisByEncadrant } from "@/components/equipment/EquipmentSynthesisByEncadrant";
 const statusLabels: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
   disponible: { label: "Disponible", variant: "default" },
   prêté: { label: "Prêté", variant: "secondary" },
@@ -647,7 +648,7 @@ const InventoryItemCard = ({ item, showActions = false }: { item: EquipmentInven
 
 const GlobalInventoryTab = () => {
   const { data: inventory, isLoading } = useGlobalEquipmentInventory();
-  const [subTab, setSubTab] = useState<"synthesis" | "list">("synthesis");
+  const [subTab, setSubTab] = useState<"synthesis" | "list" | "by-encadrant">("synthesis");
   const [ownerFilter, setOwnerFilter] = useState<string>("all");
 
   // Get unique owners from inventory
@@ -720,7 +721,7 @@ const GlobalInventoryTab = () => {
       <CardContent className="space-y-4">
         {/* Sub-tabs */}
         <Tabs value={subTab} onValueChange={(v) => setSubTab(v as typeof subTab)}>
-          <TabsList className="grid w-full grid-cols-2">
+          <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger value="synthesis" className="flex items-center gap-2">
               <BarChart3 className="h-4 w-4" />
               Synthèse
@@ -728,6 +729,10 @@ const GlobalInventoryTab = () => {
             <TabsTrigger value="list" className="flex items-center gap-2">
               <List className="h-4 w-4" />
               Liste détaillée
+            </TabsTrigger>
+            <TabsTrigger value="by-encadrant" className="flex items-center gap-2">
+              <Users className="h-4 w-4" />
+              Par encadrant
             </TabsTrigger>
           </TabsList>
 
@@ -738,6 +743,16 @@ const GlobalInventoryTab = () => {
               </div>
             ) : (
               <EquipmentSynthesis inventory={inventory || []} />
+            )}
+          </TabsContent>
+
+          <TabsContent value="by-encadrant" className="mt-4">
+            {isLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-6 w-6 animate-spin text-primary" />
+              </div>
+            ) : (
+              <EquipmentSynthesisByEncadrant inventory={inventory || []} />
             )}
           </TabsContent>
 


### PR DESCRIPTION
## Summary
- Ajout d'un 3ème sous-onglet **Par encadrant** dans Vue globale du matériel
- Tableau avec colonnes : Planche, Bouée ronde, Kit oxy, Téléphone, Autres, Valo totale
- Tous les encadrants affichés (même ceux sans matériel saisi)
- Tri par valeur décroissante
- Organisateur badge étoile (★) dans ParticipantAvatar
- Groupement encadrants/participants dans ParticipantsList (mode showNames)
- Synchronisation profiles.member_status lors de la sauvegarde admin
- Trigger DB pour sync member_status sur INSERT profil

## Test plan
- [ ] Vue globale → Par encadrant : tous les encadrants apparaissent
- [ ] Tri par valeur décroissante
- [ ] Encadrants sans matériel affichés avec —
- [ ] Mes Réservations : badge organisateur et groupement encadrants

🤖 Generated with [Claude Code](https://claude.com/claude-code)