### PR TITLE
ci: keep-alive Supabase quotidien

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,18 @@
+name: Supabase Keep Alive
+
+on:
+  schedule:
+    - cron: '0 8 * * *' # Every day at 8:00 UTC
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase
+        run: |
+          curl -s -o /dev/null -w "%{http_code}" \
+            "${{ secrets.VITE_SUPABASE_URL }}/rest/v1/" \
+            -H "apikey: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}" \
+            -H "Authorization: Bearer ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}"
+          echo " - Supabase pinged successfully"


### PR DESCRIPTION
## Summary
- Ajoute une GitHub Action planifiée (chaque jour à 8h UTC) qui ping l'API Supabase
- Évite la mise en pause automatique du projet en cas de faible activité

## Test plan
- [ ] Vérifier que le workflow s'exécute via l'onglet Actions après merge
- [ ] Tester manuellement via "Run workflow"

🤖 Generated with [Claude Code](https://claude.com/claude-code)