### PR TITLE
feat: co-encadrants sur les sorties

### DIFF
--- a/src/components/outings/OutingCard.tsx
+++ b/src/components/outings/OutingCard.tsx
@@ -202,12 +202,23 @@ const OutingCard = ({ outing, carpoolInfo }: OutingCardProps) => {
             />
           </div>
 
-          {outing.organizer && (
+          {(outing.organizer || (outing.co_instructors && outing.co_instructors.length > 0)) && (
             <div className="flex flex-col gap-1">
               <div className="flex items-center gap-2 text-muted-foreground">
                 <User className="h-4 w-4 text-primary" />
                 <span>
-                  {formatFullName(outing.organizer.first_name, outing.organizer.last_name)}
+                  {[
+                    outing.organizer
+                      ? formatFullName(outing.organizer.first_name, outing.organizer.last_name)
+                      : null,
+                    ...(outing.co_instructors ?? []).map((ci) =>
+                      ci.profile
+                        ? formatFullName(ci.profile.first_name, ci.profile.last_name)
+                        : null
+                    ),
+                  ]
+                    .filter(Boolean)
+                    .join(" & ")}
                 </span>
               </div>
               {/* Display max depth for instructor based on environment (not for pool < 6m) */}

--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -27,6 +27,16 @@ export interface Reservation {
   };
 }
 
+export interface CoInstructor {
+  user_id: string;
+  profile: {
+    first_name: string;
+    last_name: string;
+    apnea_level: string | null;
+    avatar_url: string | null;
+  } | null;
+}
+
 export interface Outing {
   id: string;
   title: string;
@@ -49,6 +59,7 @@ export interface Outing {
   dive_mode?: "boat" | "shore" | null;
   boat_id?: string | null;
   confirmed_count?: number; // Real count from SECURITY DEFINER function
+  co_instructors?: CoInstructor[];
   organizer?: {
     first_name: string;
     last_name: string;
@@ -91,6 +102,7 @@ export const useOutings = (typeFilter?: OutingType | null) => {
           *,
           organizer:profiles!outings_organizer_id_fkey(first_name, last_name, apnea_level),
           location_details:locations(id, name, address, maps_url, latitude, longitude, photo_url, max_depth),
+          co_instructors:outing_co_instructors(user_id, profile:profiles(first_name, last_name)),
           reservations(id, user_id, status, carpool_option, carpool_seats, cancelled_at, is_present, created_at)
         `)
         .eq("is_deleted", false)
@@ -163,6 +175,7 @@ export const useOuting = (outingId: string) => {
           organizer:profiles!outings_organizer_id_fkey(first_name, last_name, apnea_level),
           location_details:locations(id, name, address, maps_url, latitude, longitude, photo_url, max_depth, satellite_map_url, bathymetric_map_url),
           boat:boats(id, name, registration_number, pilot_name, pilot_phone, oxygen_location, home_port),
+          co_instructors:outing_co_instructors(user_id, profile:profiles(first_name, last_name, apnea_level, avatar_url)),
           reservations(
             id,
             user_id,
@@ -225,7 +238,8 @@ export const useMyReservations = () => {
           outing:outings(
             *,
             organizer:profiles!outings_organizer_id_fkey(first_name, last_name),
-            location_details:locations(id, name, address, maps_url)
+            location_details:locations(id, name, address, maps_url),
+            co_instructors:outing_co_instructors(user_id, profile:profiles(first_name, last_name, avatar_url))
           )
         `)
         .eq("user_id", user.id)
@@ -644,6 +658,95 @@ export const useUnlockPOSS = () => {
     },
     onError: (error: Error) => {
       toast.error(error.message || "Erreur lors du déverrouillage");
+    },
+  });
+};
+
+export const useCoInstructedOutings = () => {
+  const { user } = useAuth();
+
+  return useQuery({
+    queryKey: ["co-instructed-outings", user?.id],
+    queryFn: async () => {
+      if (!user) return [];
+
+      const { data, error } = await supabase
+        .from("outing_co_instructors")
+        .select(`
+          outing:outings(
+            *,
+            organizer:profiles!outings_organizer_id_fkey(first_name, last_name, apnea_level),
+            location_details:locations(id, name, address, maps_url),
+            reservations(id, user_id, status, carpool_option, carpool_seats, cancelled_at, is_present, created_at)
+          )
+        `)
+        .eq("user_id", user.id);
+
+      if (error) throw error;
+
+      const now = new Date();
+      const outings = (data || [])
+        .map((d) => d.outing)
+        .filter((o): o is NonNullable<typeof o> => !!o && !o.is_deleted)
+        .filter((o) => {
+          const endDate = o.end_date ? new Date(o.end_date) : new Date(o.date_time);
+          return endDate > now;
+        });
+
+      const outingsWithCounts = await Promise.all(
+        outings.map(async (outing) => {
+          const { data: countData } = await supabase
+            .rpc("get_outing_confirmed_count", { outing_uuid: outing.id });
+          return { ...outing, confirmed_count: countData ?? 0 };
+        })
+      );
+
+      return outingsWithCounts as Outing[];
+    },
+    enabled: !!user,
+  });
+};
+
+export const useAddCoInstructor = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ outingId, userId }: { outingId: string; userId: string }) => {
+      const { error } = await supabase
+        .from("outing_co_instructors")
+        .insert({ outing_id: outingId, user_id: userId });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["outing"] });
+      queryClient.invalidateQueries({ queryKey: ["co-instructed-outings"] });
+      toast.success("Co-encadrant ajouté");
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Erreur lors de l'ajout");
+    },
+  });
+};
+
+export const useRemoveCoInstructor = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ outingId, userId }: { outingId: string; userId: string }) => {
+      const { error } = await supabase
+        .from("outing_co_instructors")
+        .delete()
+        .eq("outing_id", outingId)
+        .eq("user_id", userId);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["outing"] });
+      queryClient.invalidateQueries({ queryKey: ["co-instructed-outings"] });
+      toast.success("Co-encadrant retiré");
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Erreur lors de la suppression");
     },
   });
 };

--- a/src/pages/MesSorties.tsx
+++ b/src/pages/MesSorties.tsx
@@ -24,7 +24,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { useOutings } from "@/hooks/useOutings";
+import { useOutings, useCoInstructedOutings } from "@/hooks/useOutings";
 import { useUserRole } from "@/hooks/useUserRole";
 import { useIsCurrentUserEncadrant } from "@/hooks/useIsCurrentUserEncadrant";
 import { useAuth } from "@/contexts/AuthContext";
@@ -37,9 +37,10 @@ const MesSorties = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { user, loading: authLoading } = useAuth();
-  const { isOrganizer, loading: roleLoading } = useUserRole();
+  const { isOrganizer, isAdmin, loading: roleLoading } = useUserRole();
   const { data: isEncadrantFromDirectory } = useIsCurrentUserEncadrant();
   const { data: outings, isLoading } = useOutings();
+  const { data: coInstructedOutings, isLoading: isLoadingCoInstructed } = useCoInstructedOutings();
   const { data: locations } = useLocations();
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
@@ -85,11 +86,11 @@ const MesSorties = () => {
     if (!authLoading && !roleLoading) {
       if (!user) {
         navigate("/auth");
-      } else if (!isOrganizer) {
+      } else if (!isOrganizer && !isAdmin && !isEncadrantFromDirectory) {
         navigate("/");
       }
     }
-  }, [user, isOrganizer, authLoading, roleLoading, navigate]);
+  }, [user, isOrganizer, isAdmin, isEncadrantFromDirectory, authLoading, roleLoading, navigate]);
 
   // Clear prefilled location after form closes
   const handleFormClose = () => {
@@ -104,7 +105,7 @@ const MesSorties = () => {
     ? locations?.find(l => l.id === prefilledLocationId)
     : undefined;
 
-  if (authLoading || roleLoading) {
+  if (authLoading || roleLoading || isLoading || isLoadingCoInstructed) {
     return (
       <Layout>
         <div className="flex min-h-[50vh] items-center justify-center">
@@ -114,12 +115,17 @@ const MesSorties = () => {
     );
   }
 
-  if (!isOrganizer) {
+  if (!isOrganizer && !isAdmin && !isEncadrantFromDirectory) {
     return null;
   }
 
-  // Filter outings to show only those created by the current user
-  const myOutings = outings?.filter((outing) => outing.organizer_id === user?.id) || [];
+  // Merge own outings + co-instructed outings (deduplicate by id, sort by date)
+  const ownOutings = outings?.filter((outing) => outing.organizer_id === user?.id) || [];
+  const ownOutingIds = new Set(ownOutings.map((o) => o.id));
+  const coOutings = (coInstructedOutings || []).filter((o) => !ownOutingIds.has(o.id));
+  const myOutings = [...ownOutings, ...coOutings].sort(
+    (a, b) => new Date(a.date_time).getTime() - new Date(b.date_time).getTime()
+  );
 
   const getTypeIcon = (type: string) => {
     switch (type) {
@@ -191,7 +197,8 @@ const MesSorties = () => {
                 <div className="grid gap-4 md:grid-cols-2">
                   {myOutings.map((outing) => {
                     const confirmedCount = outing.confirmed_count ?? 0;
-                    
+                    const isCoInstructed = outing.organizer_id !== user?.id;
+
                     return (
                       <div
                         key={outing.id}
@@ -200,9 +207,16 @@ const MesSorties = () => {
                         <Link to={`/outing/${outing.id}/manage`} className="block">
                           <div className="mb-2 flex items-start justify-between">
                             <div>
-                              <h4 className="font-medium text-foreground">
-                                {outing.title}
-                              </h4>
+                              <div className="flex items-center gap-2 mb-0.5">
+                                <h4 className="font-medium text-foreground">
+                                  {outing.title}
+                                </h4>
+                                {isCoInstructed && (
+                                  <Badge variant="outline" className="text-xs border-primary/50 text-primary">
+                                    Co-encadrant
+                                  </Badge>
+                                )}
+                              </div>
                               <p className="text-sm text-muted-foreground">
                                 {format(new Date(outing.date_time), "d MMMM yyyy 'à' HH'h'mm", {
                                   locale: fr,

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { format, differenceInHours } from "date-fns";
 import { fr } from "date-fns/locale";
-import { Loader2, MapPin, Calendar, Users, Navigation, Clock, XCircle, Car, UserCheck, AlertTriangle, CloudRain, CheckCircle2, Share2, Copy, Check, Phone, Lock, FileText, Unlock, Shield, ArrowDown, Gauge, Download, Mail, MessageCircle } from "lucide-react";
+import { Loader2, MapPin, Calendar, Users, Navigation, Clock, XCircle, Car, UserCheck, AlertTriangle, CloudRain, CheckCircle2, Share2, Copy, Check, Phone, Lock, FileText, Unlock, Shield, ArrowDown, Gauge, Download, Mail, MessageCircle, UserPlus, X } from "lucide-react";
 import Layout from "@/components/layout/Layout";
 import { formatFullName } from "@/lib/formatName";
 
@@ -35,7 +35,8 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUserRole } from "@/hooks/useUserRole";
-import { useOuting, useUpdateReservationPresence, useUpdateSessionReport, useCancelOuting, useArchiveOuting, useLockPOSS, useUnlockPOSS } from "@/hooks/useOutings";
+import { useOuting, useUpdateReservationPresence, useUpdateSessionReport, useCancelOuting, useArchiveOuting, useLockPOSS, useUnlockPOSS, useAddCoInstructor, useRemoveCoInstructor } from "@/hooks/useOutings";
+import { useMembersForEncadrant } from "@/hooks/useMembersForEncadrant";
 import { usePOSSGenerator } from "@/hooks/usePOSSGenerator";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
@@ -73,11 +74,16 @@ const OutingDetail = () => {
   const unlockPOSS = useUnlockPOSS();
   const possGenerator = usePOSSGenerator();
   const { data: apneaLevels } = useApneaLevels();
+  const addCoInstructor = useAddCoInstructor();
+  const removeCoInstructor = useRemoveCoInstructor();
+  const { data: allMembers } = useMembersForEncadrant();
   const [sessionReport, setSessionReport] = useState("");
   const [cancelReason, setCancelReason] = useState("Météo défavorable");
   const [linkCopied, setLinkCopied] = useState(false);
   const [sosModalOpen, setSosModalOpen] = useState(false);
   const [isGeneratingPOSS, setIsGeneratingPOSS] = useState(false);
+  const [coInstructorSearch, setCoInstructorSearch] = useState("");
+  const [coInstructorPickerOpen, setCoInstructorPickerOpen] = useState(false);
   const [selectedContact, setSelectedContact] = useState<{
     firstName: string; lastName: string; avatarUrl: string | null; email: string | null; phone: string | null;
   } | null>(null);
@@ -174,11 +180,12 @@ const OutingDetail = () => {
     }
   }, [outing?.session_report]);
 
-  // Redirect if not the organizer of this specific outing or admin
+  // Redirect if not the organizer, co-instructor or admin of this specific outing
   useEffect(() => {
     if (!authLoading && !roleLoading && !isLoading && outing) {
       const isOutingOrganizerCheck = user?.id === outing.organizer_id;
-      if (!isOutingOrganizerCheck && !isAdmin) {
+      const isCoInstructorCheck = outing.co_instructors?.some((ci) => ci.user_id === user?.id) ?? false;
+      if (!isOutingOrganizerCheck && !isCoInstructorCheck && !isAdmin) {
         navigate("/");
       }
     }
@@ -213,11 +220,12 @@ const OutingDetail = () => {
   const mapsUrl = outing.location_details?.maps_url;
   const hasActiveReservations = confirmedReservations.length > 0 || waitlistedReservations.length > 0;
   
-  // Check if user is the organizer of this specific outing OR is admin
+  // Check if user is the organizer, co-instructor or admin of this outing
   const isOutingOrganizer = user?.id === outing.organizer_id;
-  const canEditPresenceAndReport = isOutingOrganizer || isAdmin;
-  // Only the organizer of the outing or admin can cancel it
-  const canCancelOuting = isOutingOrganizer || isAdmin;
+  const isCoInstructor = outing.co_instructors?.some((ci) => ci.user_id === user?.id) ?? false;
+  const canManageOuting = isOutingOrganizer || isCoInstructor || isAdmin;
+  const canEditPresenceAndReport = canManageOuting;
+  const canCancelOuting = canManageOuting;
   
   // Check if outing can be archived (past, has attendance marked, not already archived)
   const hasAttendanceMarked = confirmedReservations.some(r => r.is_present);
@@ -501,7 +509,7 @@ const OutingDetail = () => {
             {outing.organizer && (
               <div className="mt-4 space-y-2">
                 <p className="text-sm text-muted-foreground">
-                  Encadrant : <span className="font-medium text-foreground">{formatFullName(outing.organizer.first_name, outing.organizer.last_name)}</span>
+                  Encadrant principal : <span className="font-medium text-foreground">{formatFullName(outing.organizer.first_name, outing.organizer.last_name)}</span>
                 </p>
                 {outing.outing_type !== "Piscine" && (outing.organizer_max_depth_eaa || outing.organizer_max_depth_eao) && (() => {
                   const isOpenWater = outing.outing_type === "Mer" || outing.outing_type === "Étang" || outing.outing_type === "Dépollution";
@@ -524,6 +532,84 @@ const OutingDetail = () => {
                 })()}
               </div>
             )}
+
+            {/* Co-instructors: display + management */}
+            {(() => {
+              const existingCoInstructorIds = new Set(outing.co_instructors?.map((ci) => ci.user_id) ?? []);
+              const filteredMembers = (allMembers ?? []).filter(
+                (m) => m.id !== outing.organizer_id && !existingCoInstructorIds.has(m.id) &&
+                  (coInstructorSearch === "" ||
+                    `${m.first_name} ${m.last_name}`.toLowerCase().includes(coInstructorSearch.toLowerCase()))
+              );
+
+              return (
+                <div className="mt-3 space-y-2">
+                  {/* Existing co-instructors */}
+                  {(outing.co_instructors ?? []).map((ci) => (
+                    <div key={ci.user_id} className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Users className="h-4 w-4 text-primary" />
+                      <span>
+                        Co-encadrant : <span className="font-medium text-foreground">
+                          {ci.profile ? formatFullName(ci.profile.first_name, ci.profile.last_name) : ci.user_id}
+                        </span>
+                      </span>
+                      {isOutingOrganizer && (
+                        <button
+                          onClick={() => removeCoInstructor.mutate({ outingId: outing.id, userId: ci.user_id })}
+                          className="ml-1 text-muted-foreground hover:text-destructive transition-colors"
+                          title="Retirer ce co-encadrant"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  ))}
+
+                  {/* Add co-instructor button (organizer only, future outings) */}
+                  {isOutingOrganizer && !isPast && (
+                    <Popover open={coInstructorPickerOpen} onOpenChange={setCoInstructorPickerOpen}>
+                      <PopoverTrigger asChild>
+                        <Button variant="outline" size="sm" className="gap-2 h-8 text-xs">
+                          <UserPlus className="h-3.5 w-3.5" />
+                          Ajouter un co-encadrant
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-72 p-3">
+                        <div className="space-y-2">
+                          <p className="text-sm font-medium">Choisir un co-encadrant</p>
+                          <input
+                            className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                            placeholder="Rechercher par nom..."
+                            value={coInstructorSearch}
+                            onChange={(e) => setCoInstructorSearch(e.target.value)}
+                            autoFocus
+                          />
+                          <div className="max-h-48 overflow-y-auto space-y-0.5">
+                            {filteredMembers.length === 0 ? (
+                              <p className="text-xs text-muted-foreground py-2 text-center">Aucun résultat</p>
+                            ) : (
+                              filteredMembers.map((m) => (
+                                <button
+                                  key={m.id}
+                                  className="w-full text-left px-2 py-1.5 text-sm rounded hover:bg-muted transition-colors"
+                                  onClick={() => {
+                                    addCoInstructor.mutate({ outingId: outing.id, userId: m.id });
+                                    setCoInstructorPickerOpen(false);
+                                    setCoInstructorSearch("");
+                                  }}
+                                >
+                                  {formatFullName(m.first_name, m.last_name)}
+                                </button>
+                              ))
+                            )}
+                          </div>
+                        </div>
+                      </PopoverContent>
+                    </Popover>
+                  )}
+                </div>
+              );
+            })()}
           </div>
 
           {/* 1. Weather summary banner at top */}

--- a/src/pages/Reservations.tsx
+++ b/src/pages/Reservations.tsx
@@ -116,23 +116,52 @@ const Reservations = () => {
                           </div>
 
                           {/* Participants trombinoscope */}
-                          {reservation.participants && reservation.participants.length > 0 && (
-                            <div className="mt-4 pt-3 border-t border-border/50">
-                              <div className="flex items-center gap-2 mb-3">
-                                <Users className="h-4 w-4 text-primary" />
-                                <span className="text-sm font-medium text-foreground">
-                                  Participants ({reservation.participants.length})
-                                </span>
+                          {(() => {
+                            // Co-instructors always shown as encadrants regardless of profile member_status
+                            const coInstructorIds = new Set(
+                              (reservation.outing?.co_instructors ?? []).map((ci: any) => ci.user_id)
+                            );
+
+                            // Override member_status for participants who are co-instructors
+                            const participantsWithRoles = (reservation.participants ?? []).map((p) => ({
+                              ...p,
+                              member_status: coInstructorIds.has(p.id) ? "Encadrant" : p.member_status,
+                            }));
+
+                            // Add co-instructors who have no reservation (not in participants list)
+                            const participantIdSet = new Set(participantsWithRoles.map((p) => p.id));
+                            const additionalInstructors = (reservation.outing?.co_instructors ?? [])
+                              .filter((ci: any) => ci.profile && !participantIdSet.has(ci.user_id))
+                              .map((ci: any) => ({
+                                id: ci.user_id,
+                                first_name: ci.profile.first_name,
+                                last_name: ci.profile.last_name,
+                                avatar_url: ci.profile.avatar_url ?? null,
+                                member_status: "Encadrant" as const,
+                              }));
+
+                            const allParticipants = [...participantsWithRoles, ...additionalInstructors];
+
+                            if (allParticipants.length === 0) return null;
+
+                            return (
+                              <div className="mt-4 pt-3 border-t border-border/50">
+                                <div className="flex items-center gap-2 mb-3">
+                                  <Users className="h-4 w-4 text-primary" />
+                                  <span className="text-sm font-medium text-foreground">
+                                    Participants ({allParticipants.length})
+                                  </span>
+                                </div>
+                                <ParticipantsList
+                                  participants={allParticipants}
+                                  maxVisible={10}
+                                  size="lg"
+                                  showNames
+                                  organizerId={reservation.outing?.organizer_id}
+                                />
                               </div>
-                              <ParticipantsList
-                                participants={reservation.participants}
-                                maxVisible={10}
-                                size="lg"
-                                showNames
-                                organizerId={reservation.outing?.organizer_id}
-                              />
-                            </div>
-                          )}
+                            );
+                          })()}
 
                           <Button
                             variant="outline"

--- a/supabase/migrations/20260514100000_outing_co_instructors.sql
+++ b/supabase/migrations/20260514100000_outing_co_instructors.sql
@@ -1,0 +1,38 @@
+-- Table pour les co-encadrants de sorties
+CREATE TABLE public.outing_co_instructors (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  outing_id UUID NOT NULL REFERENCES public.outings(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  added_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (outing_id, user_id)
+);
+
+ALTER TABLE public.outing_co_instructors ENABLE ROW LEVEL SECURITY;
+
+-- Tout le monde (authentifié) peut voir les co-encadrants
+CREATE POLICY "co_instructors_select"
+  ON public.outing_co_instructors FOR SELECT
+  USING (true);
+
+-- L'organisateur de la sortie ou un admin peut ajouter des co-encadrants
+CREATE POLICY "co_instructors_insert"
+  ON public.outing_co_instructors FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.outings
+      WHERE id = outing_id AND organizer_id = auth.uid()
+    )
+    OR public.has_role(auth.uid(), 'admin')
+  );
+
+-- L'organisateur, le co-encadrant lui-même ou un admin peut supprimer
+CREATE POLICY "co_instructors_delete"
+  ON public.outing_co_instructors FOR DELETE
+  USING (
+    user_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.outings
+      WHERE id = outing_id AND organizer_id = auth.uid()
+    )
+    OR public.has_role(auth.uid(), 'admin')
+  );


### PR DESCRIPTION
## Summary

- Nouvelle table `outing_co_instructors` (migration SQL + RLS)
- Co-encadrant = droits identiques à l'organisateur principal (marquer présences, générer POSS, éditer, annuler)
- L'organisateur peut ajouter/retirer des co-encadrants depuis la page de gestion de la sortie
- **Mes Sorties** affiche les sorties où l'utilisateur est co-encadrant (badge «Co-encadrant»)
- **OutingCard** affiche tous les encadrants : `Lara HÜE & Karim SAARI`
- **Mes Réservations** place les co-encadrants dans le groupe ENCADRANTS du trombinoscope

## Test plan

- [ ] Lara crée une sortie → voit le bouton «Ajouter un co-encadrant» → ajoute Karim
- [ ] Karim voit la sortie dans Mes Sorties avec badge «Co-encadrant»
- [ ] Karim accède à `/outing/{id}/manage` avec tous les droits (présences, POSS, annulation)
- [ ] OutingCard affiche «Lara HÜE & Karim SAARI»
- [ ] Mes Réservations : Karim apparaît dans la section ENCADRANTS
- [ ] Lara peut retirer Karim via le ✕ à côté de son nom
- [ ] Appliquer la migration SQL sur Supabase prod (`supabase db push`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)