### PR TITLE
fix: co-instructor picker utilise profiles.id

### DIFF
--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -36,7 +36,6 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { useAuth } from "@/contexts/AuthContext";
 import { useUserRole } from "@/hooks/useUserRole";
 import { useOuting, useUpdateReservationPresence, useUpdateSessionReport, useCancelOuting, useArchiveOuting, useLockPOSS, useUnlockPOSS, useAddCoInstructor, useRemoveCoInstructor } from "@/hooks/useOutings";
-import { useMembersForEncadrant } from "@/hooks/useMembersForEncadrant";
 import { usePOSSGenerator } from "@/hooks/usePOSSGenerator";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
@@ -76,7 +75,17 @@ const OutingDetail = () => {
   const { data: apneaLevels } = useApneaLevels();
   const addCoInstructor = useAddCoInstructor();
   const removeCoInstructor = useRemoveCoInstructor();
-  const { data: allMembers } = useMembersForEncadrant();
+  const { data: allMembers } = useQuery({
+    queryKey: ["profiles-picker"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("profiles")
+        .select("id, first_name, last_name")
+        .order("last_name");
+      if (error) throw error;
+      return data as { id: string; first_name: string; last_name: string }[];
+    },
+  });
   const [sessionReport, setSessionReport] = useState("");
   const [cancelReason, setCancelReason] = useState("Météo défavorable");
   const [linkCopied, setLinkCopied] = useState(false);


### PR DESCRIPTION
## Summary

- Bugfix FK violation lors de l'ajout d'un co-encadrant
- `get_trombinoscope_members` retourne `club_members_directory.id` mais la FK `outing_co_instructors_user_id_fkey` pointe sur `profiles.id`
- Remplacement du hook `useMembersForEncadrant` par une query directe `profiles` dans le picker

## Test plan

- [ ] Organizer ouvre la page manage d'une sortie
- [ ] Clique "Ajouter un co-encadrant" → cherche un membre → sélectionne → pas d'erreur FK

🤖 Generated with [Claude Code](https://claude.com/claude-code)