### PR TITLE
feat: trigger DB recalcule max_participants via membership_yearly_status

### DIFF
--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -707,50 +707,8 @@ export const useCoInstructedOutings = () => {
   });
 };
 
-/** Recalculate max_participants = sum of each instructor's max_participants_encadrement */
-const recalculateMaxParticipants = async (outingId: string): Promise<void> => {
-  // Fetch organizer apnea_level
-  const { data: outing } = await supabase
-    .from("outings")
-    .select("organizer_id, organizer:profiles!outings_organizer_id_fkey(apnea_level)")
-    .eq("id", outingId)
-    .single();
-
-  if (!outing) return;
-
-  // Fetch co-instructors apnea levels
-  const { data: coInstructors } = await supabase
-    .from("outing_co_instructors")
-    .select("profile:profiles(apnea_level)")
-    .eq("outing_id", outingId);
-
-  // Collect all non-null apnea levels
-  const levels = [
-    (outing.organizer as any)?.apnea_level,
-    ...((coInstructors ?? []).map((ci) => (ci.profile as any)?.apnea_level)),
-  ].filter(Boolean) as string[];
-
-  if (levels.length === 0) return;
-
-  // Fetch encadrement limits
-  const { data: levelData } = await supabase
-    .from("apnea_levels")
-    .select("code, max_participants_encadrement")
-    .in("code", levels);
-
-  const levelMap = new Map(
-    (levelData ?? []).map((l) => [l.code, l.max_participants_encadrement ?? 0])
-  );
-
-  const total = levels.reduce((sum, code) => sum + (levelMap.get(code) ?? 0), 0);
-
-  if (total > 0) {
-    await supabase
-      .from("outings")
-      .update({ max_participants: total })
-      .eq("id", outingId);
-  }
-};
+// max_participants recalculated automatically by DB trigger trg_recalculate_max_participants
+// on INSERT/DELETE in outing_co_instructors (uses membership_yearly_status as source)
 
 export const useAddCoInstructor = () => {
   const queryClient = useQueryClient();
@@ -761,7 +719,6 @@ export const useAddCoInstructor = () => {
         .from("outing_co_instructors")
         .insert({ outing_id: outingId, user_id: userId });
       if (error) throw error;
-      await recalculateMaxParticipants(outingId);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["outing"] });
@@ -786,7 +743,6 @@ export const useRemoveCoInstructor = () => {
         .eq("outing_id", outingId)
         .eq("user_id", userId);
       if (error) throw error;
-      await recalculateMaxParticipants(outingId);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["outing"] });

--- a/supabase/migrations/20260514110000_recalculate_max_participants_trigger.sql
+++ b/supabase/migrations/20260514110000_recalculate_max_participants_trigger.sql
@@ -1,0 +1,59 @@
+-- Fonction recalculant max_participants d'une sortie
+-- = somme des max_participants_encadrement de l'organisateur + co-encadrants
+-- Source des niveaux : membership_yearly_status (saison courante)
+CREATE OR REPLACE FUNCTION public.recalculate_outing_max_participants(p_outing_id uuid)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_season_year integer;
+  v_total integer := 0;
+  v_organizer_id uuid;
+BEGIN
+  v_season_year := CASE
+    WHEN EXTRACT(MONTH FROM CURRENT_DATE) >= 9
+    THEN EXTRACT(YEAR FROM CURRENT_DATE)::integer + 1
+    ELSE EXTRACT(YEAR FROM CURRENT_DATE)::integer
+  END;
+
+  SELECT organizer_id INTO v_organizer_id FROM public.outings WHERE id = p_outing_id;
+  IF v_organizer_id IS NULL THEN RETURN; END IF;
+
+  SELECT COALESCE(SUM(al.max_participants_encadrement), 0) INTO v_total
+  FROM (
+    SELECT p.email FROM public.profiles p WHERE p.id = v_organizer_id
+    UNION ALL
+    SELECT p.email FROM public.outing_co_instructors oci
+    JOIN public.profiles p ON p.id = oci.user_id
+    WHERE oci.outing_id = p_outing_id
+  ) instructors
+  JOIN public.club_members_directory cmd ON lower(cmd.email) = lower(instructors.email)
+  JOIN public.membership_yearly_status mys
+    ON mys.member_id = cmd.id AND mys.season_year = v_season_year
+  JOIN public.apnea_levels al ON al.code = mys.apnea_level
+  WHERE al.max_participants_encadrement IS NOT NULL;
+
+  IF v_total > 0 THEN
+    UPDATE public.outings SET max_participants = v_total WHERE id = p_outing_id;
+  END IF;
+END;
+$$;
+
+-- Trigger function
+CREATE OR REPLACE FUNCTION public.trg_recalculate_outing_max_participants()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    PERFORM public.recalculate_outing_max_participants(OLD.outing_id);
+    RETURN OLD;
+  ELSE
+    PERFORM public.recalculate_outing_max_participants(NEW.outing_id);
+    RETURN NEW;
+  END IF;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_recalculate_max_participants ON public.outing_co_instructors;
+CREATE TRIGGER trg_recalculate_max_participants
+  AFTER INSERT OR DELETE ON public.outing_co_instructors
+  FOR EACH ROW EXECUTE FUNCTION public.trg_recalculate_outing_max_participants();


### PR DESCRIPTION
## Summary

- Trigger Postgres `trg_recalculate_max_participants` sur `outing_co_instructors`
- Utilise `membership_yearly_status` (pas `profiles.apnea_level` qui est souvent null)
- Supprime le recalcul côté frontend (trigger = source de vérité)
- Karim EA2 (8) + Lara EA2 (8) → 16 places automatiquement

## Test plan

- [ ] Ajouter co-encadrant → max_participants mis à jour automatiquement
- [ ] Retirer co-encadrant → max_participants recalculé
- [ ] Vérifier via DB: `SELECT max_participants FROM outings WHERE id = '...'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)