### PR TITLE
fix: compter les co-encadrants dans les effectifs de la sortie

### DIFF
--- a/src/components/outings/OutingCard.tsx
+++ b/src/components/outings/OutingCard.tsx
@@ -70,7 +70,9 @@ const OutingCard = ({ outing, carpoolInfo }: OutingCardProps) => {
   };
 
   // Use real confirmed count from SECURITY DEFINER function (bypasses RLS)
-  const currentParticipants = outing.confirmed_count ?? 0;
+  // Co-instructors count as participants in the headcount (they occupy a spot)
+  const coInstructorsCount = outing.co_instructors?.length ?? 0;
+  const currentParticipants = (outing.confirmed_count ?? 0) + coInstructorsCount;
   const isFull = currentParticipants >= outing.max_participants;
   const userReservation = outing.reservations?.find((r) => r.user_id === user?.id && r.status !== "annulé");
   const isRegistered = !!userReservation;


### PR DESCRIPTION
## Summary
- Co-encadrants comptés dans le compteur `X/Y participants` de la carte sortie
- `currentParticipants = confirmed_count + co_instructors.length`
- Exemple : 1 réservation + Lara co-encadrante → affiche `2/16` au lieu de `1/16`

## Test plan
- [ ] Sortie avec 1 réservation + 1 co-encadrant → `2/N participants`
- [ ] Sortie sans co-encadrant → compteur inchangé
- [ ] `spotsLeft` reflète le nouveau total

🤖 Generated with [Claude Code](https://claude.com/claude-code)