### PR TITLE
feat(security): tabs layout + PDF generator in both tabs

### DIFF
--- a/src/components/pdf/FicheSecuriteGenerator.tsx
+++ b/src/components/pdf/FicheSecuriteGenerator.tsx
@@ -18,6 +18,7 @@ export const FicheSecuriteGenerator = () => {
 
     try {
       await new Promise((r) => setTimeout(r, 500));
+      await document.fonts.ready;
 
       const pdf = new jsPDF({
         orientation: "portrait",

--- a/src/components/pdf/FicheSecuriteGenerator.tsx
+++ b/src/components/pdf/FicheSecuriteGenerator.tsx
@@ -17,8 +17,8 @@ export const FicheSecuriteGenerator = () => {
     const toastId = toast.loading("Génération de la fiche sécurité...");
 
     try {
-      await new Promise((r) => setTimeout(r, 500));
       await document.fonts.ready;
+      await new Promise((r) => setTimeout(r, 1000));
 
       const pdf = new jsPDF({
         orientation: "portrait",
@@ -30,7 +30,7 @@ export const FicheSecuriteGenerator = () => {
       if (!page) throw new Error("Page not found");
 
       const canvas = await html2canvas(page, {
-        scale: 3,
+        scale: 5,
         useCORS: true,
         allowTaint: true,
         logging: false,

--- a/src/components/pdf/FicheSecuriteGenerator.tsx
+++ b/src/components/pdf/FicheSecuriteGenerator.tsx
@@ -30,7 +30,7 @@ export const FicheSecuriteGenerator = () => {
       if (!page) throw new Error("Page not found");
 
       const canvas = await html2canvas(page, {
-        scale: 5,
+        scale: 4,
         useCORS: true,
         allowTaint: true,
         logging: false,
@@ -39,9 +39,9 @@ export const FicheSecuriteGenerator = () => {
         windowHeight: 1123,
       });
 
-      const imgData = canvas.toDataURL("image/png");
+      const imgData = canvas.toDataURL("image/jpeg", 0.92);
       // A4 portrait: 210mm x 297mm
-      pdf.addImage(imgData, "PNG", 0, 0, 210, 297);
+      pdf.addImage(imgData, "JPEG", 0, 0, 210, 297);
 
       pdf.save("Fiche_Securite_TeamOxygen.pdf");
       toast.success("Fiche téléchargée !", { id: toastId });

--- a/src/components/pdf/FicheSecuriteGenerator.tsx
+++ b/src/components/pdf/FicheSecuriteGenerator.tsx
@@ -1,0 +1,84 @@
+import { useState, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { FileDown, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import html2canvas from "html2canvas";
+import jsPDF from "jspdf";
+import { PDFPageSecuritePortrait } from "./pages/PDFPageSecuritePortrait";
+
+export const FicheSecuriteGenerator = () => {
+  const [isGenerating, setIsGenerating] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const generatePDF = async () => {
+    if (!containerRef.current) return;
+
+    setIsGenerating(true);
+    const toastId = toast.loading("Génération de la fiche sécurité...");
+
+    try {
+      await new Promise((r) => setTimeout(r, 500));
+
+      const pdf = new jsPDF({
+        orientation: "portrait",
+        unit: "mm",
+        format: "a4",
+      });
+
+      const page = containerRef.current.querySelector("[data-pdf-page]") as HTMLElement;
+      if (!page) throw new Error("Page not found");
+
+      const canvas = await html2canvas(page, {
+        scale: 3,
+        useCORS: true,
+        allowTaint: true,
+        logging: false,
+        backgroundColor: "#ffffff",
+        windowWidth: 794,
+        windowHeight: 1123,
+      });
+
+      const imgData = canvas.toDataURL("image/png");
+      // A4 portrait: 210mm x 297mm
+      pdf.addImage(imgData, "PNG", 0, 0, 210, 297);
+
+      pdf.save("Fiche_Securite_TeamOxygen.pdf");
+      toast.success("Fiche téléchargée !", { id: toastId });
+    } catch {
+      toast.error("Erreur lors de la génération", { id: toastId });
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return (
+    <>
+      <Button onClick={generatePDF} disabled={isGenerating} className="gap-2">
+        {isGenerating ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Génération...
+          </>
+        ) : (
+          <>
+            <FileDown className="h-4 w-4" />
+            Télécharger le PDF
+          </>
+        )}
+      </Button>
+
+      {/* Hidden portrait render container */}
+      <div
+        ref={containerRef}
+        style={{
+          position: "fixed",
+          left: "-10000px",
+          top: 0,
+          width: "794px",
+        }}
+      >
+        <PDFPageSecuritePortrait />
+      </div>
+    </>
+  );
+};

--- a/src/components/pdf/FicheSecuriteGenerator.tsx
+++ b/src/components/pdf/FicheSecuriteGenerator.tsx
@@ -30,7 +30,7 @@ export const FicheSecuriteGenerator = () => {
       if (!page) throw new Error("Page not found");
 
       const canvas = await html2canvas(page, {
-        scale: 4,
+        scale: 5,
         useCORS: true,
         allowTaint: true,
         logging: false,
@@ -39,7 +39,7 @@ export const FicheSecuriteGenerator = () => {
         windowHeight: 1123,
       });
 
-      const imgData = canvas.toDataURL("image/jpeg", 0.92);
+      const imgData = canvas.toDataURL("image/jpeg", 0.95);
       // A4 portrait: 210mm x 297mm
       pdf.addImage(imgData, "JPEG", 0, 0, 210, 297);
 

--- a/src/components/pdf/pages/PDFPageSecurite1.tsx
+++ b/src/components/pdf/pages/PDFPageSecurite1.tsx
@@ -1,0 +1,209 @@
+import { PDFPageWrapper } from "../PDFPageWrapper";
+import logoTeamOxygen from "@/assets/logo-team-oxygen.webp";
+
+export const PDFPageSecurite1 = () => {
+  return (
+    <PDFPageWrapper pageNumber={1} totalPages={2}>
+      <div style={{ display: "flex", height: "100%", gap: "20px" }}>
+
+        {/* LEFT: Header + Sections 1, 3, 5 */}
+        <div style={{ width: "430px", flexShrink: 0, display: "flex", flexDirection: "column", gap: "12px" }}>
+
+          {/* Header */}
+          <div style={{
+            background: "linear-gradient(135deg, #0c2340 0%, #1e3a5f 60%, #0891b2 100%)",
+            borderRadius: "12px",
+            padding: "16px 20px",
+            color: "white",
+            display: "flex",
+            alignItems: "center",
+            gap: "16px",
+          }}>
+            <img src={logoTeamOxygen} alt="Team Oxygen" style={{ width: "64px", height: "auto", flexShrink: 0 }} />
+            <div>
+              <div style={{ fontSize: "9px", fontWeight: "700", letterSpacing: "2px", color: "#7dd3fc", textTransform: "uppercase", marginBottom: "3px" }}>
+                Fiche Sécurité
+              </div>
+              <div style={{ fontSize: "22px", fontWeight: "800", color: "#ffffff", lineHeight: 1.1, marginBottom: "3px" }}>
+                TEAM OXYGEN
+              </div>
+              <div style={{ fontSize: "10px", fontStyle: "italic", color: "#bae6fd", marginBottom: "5px" }}>
+                BE AN ECO EXPLORER
+              </div>
+              <div style={{ fontSize: "10px", color: "#7dd3fc", fontStyle: "italic" }}>
+                Prendre soin de soi, des autres et de la mer
+              </div>
+            </div>
+          </div>
+
+          {/* Section 1 */}
+          <SectionCard number="1" title="Prendre soin de soi" subtitle="Sécurité individuelle" color="#0891b2">
+            <Item label="Écoute & modération">
+              Être à l'écoute de soi et raisonnable. Nous sommes notre première sécurité.
+            </Item>
+            <Item label="Préparation mentale">
+              Engager la pratique de l'apnée dans un état relaxé.
+            </Item>
+            <Item label="Philosophie de pratique">
+              Ne pas rechercher la performance à tout prix — progresser dans le plaisir.
+            </Item>
+            <Item label="Hydratation">
+              Bien s'hydrater avant et après chaque plongée.
+            </Item>
+          </SectionCard>
+
+          {/* Section 3 */}
+          <SectionCard number="3" title="Organisation & Ponctualité" subtitle="Respect des engagements" color="#0d9488">
+            <Item label="Respect des horaires">
+              Les horaires doivent être scrupuleusement respectés, avec une marge de sécurité intégrée.
+            </Item>
+            <Item label="Anticipation des annulations">
+              Éviter les annulations à moins de 24 heures de la sortie pour respecter les encadrants.
+            </Item>
+          </SectionCard>
+
+          {/* Section 5 */}
+          <SectionCard number="5" title="Respect de l'environnement" subtitle="Éco-responsabilité & Encadrement" color="#059669">
+            <Item label="Consignes encadrant">
+              Rester vigilant aux dangers liés à la mer et bien respecter les consignes de l'encadrant.
+            </Item>
+            <Item label="Éco-responsabilité">
+              Respecter la faune et la flore — nous sommes des invités dans leur milieu.
+            </Item>
+            <div style={{
+              marginTop: "8px",
+              padding: "8px 10px",
+              background: "linear-gradient(135deg, #ecfdf5, #d1fae5)",
+              border: "1.5px solid #059669",
+              borderRadius: "7px",
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+            }}>
+              <span style={{ fontSize: "18px" }}>🌿</span>
+              <span style={{ fontSize: "10px", fontWeight: "700", color: "#065f46" }}>
+                Zéro déchet · Zéro impact · Maximum de respect
+              </span>
+            </div>
+          </SectionCard>
+        </div>
+
+        {/* RIGHT: Section 2 full height */}
+        <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+          <SectionCard number="2" title="Équipement Obligatoire & Check-list Matériel" subtitle="À vérifier avant chaque sortie" color="#dc2626" fullHeight>
+
+            <div style={{ fontSize: "10px", fontWeight: "700", color: "#374151", marginBottom: "10px", textTransform: "uppercase", letterSpacing: "0.5px" }}>
+              Équipement requis par apnéiste
+            </div>
+
+            {[
+              { icon: "🦵", label: "Palmes" },
+              { icon: "🤿", label: "Masque" },
+              { icon: "🌊", label: "Tuba" },
+              { icon: "🩱", label: "Combinaison (néoprène refendu recommandé pour une isolation thermique optimale)" },
+              { icon: "⚖️", label: "Ceinture de plombs" },
+              { icon: "💧", label: "Gourde d'eau — obligatoire sur toutes les sorties" },
+            ].map((item) => (
+              <div key={item.label} style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "10px",
+                padding: "7px 10px",
+                marginBottom: "5px",
+                backgroundColor: "#f8fafc",
+                borderRadius: "7px",
+                border: "1px solid #e2e8f0",
+              }}>
+                <span style={{ fontSize: "16px", flexShrink: 0 }}>{item.icon}</span>
+                <span style={{ fontSize: "11px", color: "#374151", fontWeight: "500", flex: 1 }}>{item.label}</span>
+                <CheckIcon />
+              </div>
+            ))}
+
+            <div style={{ marginTop: "14px", display: "flex", gap: "12px" }}>
+              <div style={{ flex: 1, padding: "10px 12px", backgroundColor: "#fef3c7", borderRadius: "8px", border: "1px solid #fcd34d" }}>
+                <div style={{ fontSize: "10px", fontWeight: "700", color: "#92400e", marginBottom: "4px" }}>✓ Check avant départ</div>
+                <div style={{ fontSize: "10px", color: "#78350f" }}>Faire un check matos avant de quitter la maison et d'aller à l'eau.</div>
+              </div>
+              <div style={{ flex: 1, padding: "10px 12px", backgroundColor: "#f0fdf4", borderRadius: "8px", border: "1px solid #86efac" }}>
+                <div style={{ fontSize: "10px", fontWeight: "700", color: "#166534", marginBottom: "4px" }}>✓ Adaptation météo</div>
+                <div style={{ fontSize: "10px", color: "#14532d" }}>Choisir le matériel en fonction des conditions météo et de l'activité ciblée.</div>
+              </div>
+            </div>
+
+            {/* Warning */}
+            <div style={{
+              marginTop: "14px",
+              padding: "12px 16px",
+              backgroundColor: "#fef2f2",
+              border: "2px solid #dc2626",
+              borderRadius: "9px",
+              display: "flex",
+              alignItems: "center",
+              gap: "12px",
+            }}>
+              <span style={{ fontSize: "24px", flexShrink: 0 }}>⚠️</span>
+              <div>
+                <div style={{ fontSize: "11px", fontWeight: "800", color: "#dc2626", marginBottom: "3px", textTransform: "uppercase", letterSpacing: "0.5px" }}>
+                  Règle stricte
+                </div>
+                <div style={{ fontSize: "10px", color: "#7f1d1d", lineHeight: 1.5 }}>
+                  En cas de manquement à l'un de ces éléments de sécurité,{" "}
+                  <strong>le refus de sortir en mer sera appliqué immédiatement.</strong>
+                </div>
+              </div>
+            </div>
+          </SectionCard>
+        </div>
+      </div>
+    </PDFPageWrapper>
+  );
+};
+
+const CheckIcon = () => (
+  <svg style={{ width: "14px", height: "14px", color: "#16a34a", flexShrink: 0 }} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+const SectionCard = ({
+  number, title, subtitle, color, children, fullHeight,
+}: {
+  number: string; title: string; subtitle?: string; color: string;
+  children: React.ReactNode; fullHeight?: boolean;
+}) => (
+  <div style={{
+    border: `1.5px solid ${color}30`,
+    borderRadius: "10px",
+    overflow: "hidden",
+    flex: fullHeight ? 1 : undefined,
+    display: "flex",
+    flexDirection: "column",
+  }}>
+    <div style={{ backgroundColor: color, padding: "8px 14px", display: "flex", alignItems: "center", gap: "10px" }}>
+      <div style={{
+        width: "22px", height: "22px", borderRadius: "50%",
+        backgroundColor: "rgba(255,255,255,0.25)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        fontSize: "12px", fontWeight: "800", color: "white", flexShrink: 0,
+      }}>
+        {number}
+      </div>
+      <div>
+        <div style={{ fontSize: "13px", fontWeight: "700", color: "white" }}>{title}</div>
+        {subtitle && <div style={{ fontSize: "9px", color: "rgba(255,255,255,0.85)" }}>{subtitle}</div>}
+      </div>
+    </div>
+    <div style={{ padding: "12px 14px", flex: fullHeight ? 1 : undefined }}>{children}</div>
+  </div>
+);
+
+const Item = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div style={{ marginBottom: "8px", display: "flex", gap: "8px" }}>
+    <div style={{ width: "3px", minWidth: "3px", borderRadius: "2px", backgroundColor: "#0891b2", marginTop: "3px" }} />
+    <div style={{ lineHeight: 1.45 }}>
+      <span style={{ fontSize: "10px", fontWeight: "700", color: "#1e3a5f" }}>{label} : </span>
+      <span style={{ fontSize: "10px", color: "#374151" }}>{children}</span>
+    </div>
+  </div>
+);

--- a/src/components/pdf/pages/PDFPageSecurite2.tsx
+++ b/src/components/pdf/pages/PDFPageSecurite2.tsx
@@ -1,0 +1,190 @@
+import { PDFPageWrapper } from "../PDFPageWrapper";
+import logoTeamOxygen from "@/assets/logo-team-oxygen.webp";
+
+export const PDFPageSecurite2 = () => {
+  return (
+    <PDFPageWrapper pageNumber={2} totalPages={2}>
+      <div style={{ display: "flex", height: "100%", gap: "20px" }}>
+
+        {/* LEFT: Section 4 */}
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "16px" }}>
+          <SectionCard number="4" title="Prendre soin de son binôme" subtitle="Sécurité collective" color="#7c3aed">
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px", marginBottom: "12px" }}>
+              <Item label="Niveau équivalent">
+                Les binômes doivent être de même niveau pour garantir une sécurité optimale en toutes circonstances.
+              </Item>
+              <Item label="Responsabilité">
+                Prendre son rôle de binôme aussi sérieusement que ses propres apnées.
+              </Item>
+              <Item label="Communication">
+                Bien communiquer avec son binôme — avant, pendant et après les plongées.
+              </Item>
+              <Item label="Cohésion">
+                Garder un esprit d'équipe et de partage en toutes circonstances.
+              </Item>
+            </div>
+          </SectionCard>
+
+          {/* Binôme visual rules */}
+          <div style={{
+            border: "1.5px solid #7c3aed30",
+            borderRadius: "10px",
+            overflow: "hidden",
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+          }}>
+            <div style={{ backgroundColor: "#7c3aed", padding: "8px 14px", display: "flex", alignItems: "center", gap: "10px" }}>
+              <span style={{ fontSize: "16px" }}>🤝</span>
+              <div style={{ fontSize: "13px", fontWeight: "700", color: "white" }}>Mes engagements de binôme</div>
+            </div>
+            <div style={{ padding: "14px", flex: 1, display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px", alignContent: "start" }}>
+              {[
+                { icon: "👁️", text: "Je surveille mon binôme en permanence" },
+                { icon: "🚫", text: "Je ne le quitte jamais des yeux en plongée" },
+                { icon: "🤙", text: "Je signale tout inconfort ou malaise immédiatement" },
+                { icon: "⏱️", text: "Je respecte les temps de surface imposés" },
+                { icon: "🔄", text: "Un plonge, l'autre surveille — j'alterne toujours" },
+                { icon: "📢", text: "Je donne l'alerte sans hésitation si besoin" },
+              ].map((rule) => (
+                <div key={rule.text} style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "10px",
+                  padding: "10px 12px",
+                  backgroundColor: "#faf5ff",
+                  borderRadius: "8px",
+                  border: "1px solid #e9d5ff",
+                }}>
+                  <span style={{ fontSize: "18px", flexShrink: 0 }}>{rule.icon}</span>
+                  <span style={{ fontSize: "11px", color: "#374151", lineHeight: 1.4 }}>{rule.text}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* RIGHT: Recap + Footer */}
+        <div style={{ width: "320px", flexShrink: 0, display: "flex", flexDirection: "column", gap: "16px" }}>
+
+          {/* Recap card */}
+          <div style={{
+            border: "1.5px solid #0891b230",
+            borderRadius: "10px",
+            overflow: "hidden",
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+          }}>
+            <div style={{ backgroundColor: "#1e3a5f", padding: "8px 14px" }}>
+              <div style={{ fontSize: "13px", fontWeight: "700", color: "white" }}>Récapitulatif sécurité</div>
+              <div style={{ fontSize: "9px", color: "rgba(255,255,255,0.75)" }}>À retenir avant chaque sortie</div>
+            </div>
+            <div style={{ padding: "14px", flex: 1 }}>
+              {[
+                { num: "1", color: "#0891b2", text: "Je suis à l'écoute de moi-même" },
+                { num: "2", color: "#dc2626", text: "Mon équipement est complet et vérifié" },
+                { num: "3", color: "#0d9488", text: "Je suis ponctuel et organisé" },
+                { num: "4", color: "#7c3aed", text: "Je prends soin de mon binôme" },
+                { num: "5", color: "#059669", text: "Je respecte la mer et ses habitants" },
+              ].map((item) => (
+                <div key={item.num} style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "10px",
+                  padding: "9px 10px",
+                  marginBottom: "7px",
+                  backgroundColor: "#f8fafc",
+                  borderRadius: "7px",
+                  border: `1.5px solid ${item.color}30`,
+                }}>
+                  <div style={{
+                    width: "24px", height: "24px", borderRadius: "50%",
+                    backgroundColor: item.color,
+                    display: "flex", alignItems: "center", justifyContent: "center",
+                    fontSize: "12px", fontWeight: "800", color: "white", flexShrink: 0,
+                  }}>
+                    {item.num}
+                  </div>
+                  <span style={{ fontSize: "11px", color: "#1e3a5f", fontWeight: "600" }}>{item.text}</span>
+                </div>
+              ))}
+
+              {/* Motto */}
+              <div style={{
+                marginTop: "12px",
+                padding: "12px",
+                background: "linear-gradient(135deg, #eff6ff, #ecfdf5)",
+                borderRadius: "8px",
+                border: "1px solid #bfdbfe",
+                textAlign: "center",
+              }}>
+                <div style={{ fontSize: "11px", fontWeight: "700", color: "#1e3a5f", marginBottom: "3px" }}>
+                  Notre philosophie
+                </div>
+                <div style={{ fontSize: "10px", fontStyle: "italic", color: "#374151", lineHeight: 1.5 }}>
+                  « Prendre soin de soi, des autres et de la mer »
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div style={{
+            background: "linear-gradient(135deg, #0c2340 0%, #1e3a5f 60%, #0891b2 100%)",
+            borderRadius: "10px",
+            padding: "14px 16px",
+            display: "flex",
+            alignItems: "center",
+            gap: "12px",
+          }}>
+            <img src={logoTeamOxygen} alt="Team Oxygen" style={{ width: "48px", height: "auto", flexShrink: 0 }} />
+            <div>
+              <div style={{ fontSize: "13px", fontWeight: "800", color: "white", marginBottom: "2px" }}>Team Oxygen</div>
+              <div style={{ fontSize: "9px", color: "#bae6fd", marginBottom: "3px" }}>
+                Association éco-responsable de plongée et apnée
+              </div>
+              <div style={{ fontSize: "9px", color: "#7dd3fc" }}>
+                Région Martigues-Marseille · BE AN ECO EXPLORER
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </PDFPageWrapper>
+  );
+};
+
+const SectionCard = ({
+  number, title, subtitle, color, children,
+}: {
+  number: string; title: string; subtitle?: string; color: string; children: React.ReactNode;
+}) => (
+  <div style={{ border: `1.5px solid ${color}30`, borderRadius: "10px", overflow: "hidden" }}>
+    <div style={{ backgroundColor: color, padding: "8px 14px", display: "flex", alignItems: "center", gap: "10px" }}>
+      <div style={{
+        width: "22px", height: "22px", borderRadius: "50%",
+        backgroundColor: "rgba(255,255,255,0.25)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        fontSize: "12px", fontWeight: "800", color: "white", flexShrink: 0,
+      }}>
+        {number}
+      </div>
+      <div>
+        <div style={{ fontSize: "13px", fontWeight: "700", color: "white" }}>{title}</div>
+        {subtitle && <div style={{ fontSize: "9px", color: "rgba(255,255,255,0.85)" }}>{subtitle}</div>}
+      </div>
+    </div>
+    <div style={{ padding: "12px 14px" }}>{children}</div>
+  </div>
+);
+
+const Item = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div style={{ display: "flex", gap: "8px" }}>
+    <div style={{ width: "3px", minWidth: "3px", borderRadius: "2px", backgroundColor: "#7c3aed", marginTop: "3px" }} />
+    <div style={{ lineHeight: 1.45 }}>
+      <span style={{ fontSize: "10px", fontWeight: "700", color: "#1e3a5f" }}>{label} : </span>
+      <span style={{ fontSize: "10px", color: "#374151" }}>{children}</span>
+    </div>
+  </div>
+);

--- a/src/components/pdf/pages/PDFPageSecuritePortrait.tsx
+++ b/src/components/pdf/pages/PDFPageSecuritePortrait.tsx
@@ -292,11 +292,14 @@ const SectionCard = ({
       <div style={{
         width: "20px", height: "20px", borderRadius: "50%",
         backgroundColor: "rgba(255,255,255,0.25)",
-        display: "block",
-        textAlign: "center", lineHeight: "20px",
-        fontSize: "11px", fontWeight: "800", color: "white", flexShrink: 0,
+        flexShrink: 0,
+        position: "relative",
       }}>
-        {number}
+        <span style={{
+          position: "absolute", top: "50%", left: "50%",
+          transform: "translate(-50%, -50%)",
+          fontSize: "11px", fontWeight: "800", color: "white", lineHeight: 1,
+        }}>{number}</span>
       </div>
       <div>
         <div style={{ fontSize: "12px", fontWeight: "700", color: "white" }}>{title}</div>

--- a/src/components/pdf/pages/PDFPageSecuritePortrait.tsx
+++ b/src/components/pdf/pages/PDFPageSecuritePortrait.tsx
@@ -166,18 +166,18 @@ export const PDFPageSecuritePortrait = () => {
               { svg: <IconGourde />, label: "Gourde d'eau (obligatoire)", desc: "Prévient crampes et syncopes. Boire avant, pendant et après chaque session." },
             ].map((item) => (
               <div key={item.label} style={{
-                display: "flex", alignItems: "center", gap: "8px",
-                padding: "3px 8px", marginBottom: "3px",
+                display: "flex", alignItems: "flex-start", gap: "8px",
+                padding: "5px 8px", marginBottom: "3px",
                 backgroundColor: "#f8fafc", borderRadius: "6px", border: "1px solid #e2e8f0",
               }}>
-                <div style={{ width: "26px", height: "26px", flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
+                <div style={{ width: "26px", height: "26px", flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center", marginTop: "1px" }}>
                   {item.svg}
                 </div>
                 <div style={{ flex: 1 }}>
                   <div style={{ fontSize: "10px", color: "#374151", fontWeight: "600" }}>{item.label}</div>
-                  <div style={{ fontSize: "8.5px", color: "#64748b", lineHeight: 1.3, marginTop: "1px" }}>{item.desc}</div>
+                  <div style={{ fontSize: "8.5px", color: "#64748b", lineHeight: 1.35, marginTop: "2px" }}>{item.desc}</div>
                 </div>
-                <CheckIcon />
+                <CheckIcon style={{ marginTop: "3px" }} />
               </div>
             ))}
           </div>
@@ -204,8 +204,9 @@ export const PDFPageSecuritePortrait = () => {
               <div>
                 <div style={{ fontSize: "10px", fontWeight: "800", color: "#dc2626", marginBottom: "3px", textTransform: "uppercase" }}>Règle stricte</div>
                 <div style={{ fontSize: "10px", color: "#7f1d1d", lineHeight: 1.5 }}>
-                  En cas de manquement,{" "}
-                  <strong>le refus de sortir en mer sera appliqué immédiatement.</strong>
+                  Tout apnéiste ne disposant pas de la liste exhaustive du matériel,{" "}
+                  ou présentant un équipement en mauvais état,{" "}
+                  <strong>se verra refuser la sortie en mer par l'encadrant.</strong>
                 </div>
               </div>
             </div>
@@ -251,11 +252,11 @@ export const PDFPageSecuritePortrait = () => {
       <div style={{
         border: "1.5px solid #7c3aed30", borderRadius: "10px", overflow: "hidden", flexShrink: 0,
       }}>
-        <div style={{ backgroundColor: "#7c3aed", padding: "7px 14px", display: "flex", alignItems: "center", gap: "8px" }}>
+        <div style={{ backgroundColor: "#7c3aed", padding: "5px 14px", display: "flex", alignItems: "center", gap: "8px" }}>
           <span style={{ fontSize: "13px" }}>🤝</span>
           <div style={{ fontSize: "12px", fontWeight: "700", color: "white" }}>Mes engagements de binôme</div>
         </div>
-        <div style={{ padding: "10px 12px", display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "7px" }}>
+        <div style={{ padding: "6px 10px", display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "5px" }}>
           {[
             { icon: "👁️", text: "Je surveille mon binôme en permanence" },
             { icon: "🚫", text: "Je ne le quitte jamais des yeux en plongée" },
@@ -265,12 +266,12 @@ export const PDFPageSecuritePortrait = () => {
             { icon: "📢", text: "Je donne l'alerte sans hésitation" },
           ].map((rule) => (
             <div key={rule.text} style={{
-              display: "flex", alignItems: "center", gap: "7px",
-              padding: "6px 9px",
+              display: "flex", alignItems: "center", gap: "6px",
+              padding: "4px 8px",
               backgroundColor: "#faf5ff", borderRadius: "6px", border: "1px solid #e9d5ff",
             }}>
-              <span style={{ fontSize: "14px", flexShrink: 0 }}>{rule.icon}</span>
-              <span style={{ fontSize: "10px", color: "#374151" }}>{rule.text}</span>
+              <span style={{ fontSize: "13px", flexShrink: 0 }}>{rule.icon}</span>
+              <span style={{ fontSize: "9.5px", color: "#374151" }}>{rule.text}</span>
             </div>
           ))}
         </div>

--- a/src/components/pdf/pages/PDFPageSecuritePortrait.tsx
+++ b/src/components/pdf/pages/PDFPageSecuritePortrait.tsx
@@ -88,11 +88,11 @@ export const PDFPageSecuritePortrait = () => {
         fontFamily: "Inter, system-ui, sans-serif",
         position: "relative",
         overflow: "hidden",
-        padding: "28px 36px",
+        padding: "20px 36px",
         boxSizing: "border-box",
         display: "flex",
         flexDirection: "column",
-        gap: "9px",
+        gap: "8px",
       }}
     >
       {/* Header */}
@@ -158,22 +158,25 @@ export const PDFPageSecuritePortrait = () => {
               Équipement requis par apnéiste
             </div>
             {[
-              { svg: <IconPalmes />, label: "Palmes" },
-              { svg: <IconMasque />, label: "Masque" },
-              { svg: <IconTuba />, label: "Tuba" },
-              { svg: <IconCombinaison />, label: "Combinaison (néoprène refendu recommandé)" },
-              { svg: <IconCeinture />, label: "Ceinture de plombs" },
-              { svg: <IconGourde />, label: "Gourde d'eau (obligatoire)" },
+              { svg: <IconPalmes />, label: "Palmes", desc: "Propulsion efficace — préserve l'oxygène, mouvement de tout le corps." },
+              { svg: <IconMasque />, label: "Masque", desc: "Vision sous-marine et espace nasal pour l'équilibrage des pressions." },
+              { svg: <IconTuba />, label: "Tuba", desc: "Ventilation en surface sans effort — préserve la capacité pulmonaire." },
+              { svg: <IconCombinaison />, label: "Combinaison (néoprène refendu recommandé)", desc: "Protection thermique contre l'hypothermie — le refendu limite les entrées d'eau." },
+              { svg: <IconCeinture />, label: "Ceinture de plombs", desc: "Compense la flottabilité — descente fluide, neutralité à mi-profondeur." },
+              { svg: <IconGourde />, label: "Gourde d'eau (obligatoire)", desc: "Prévient crampes et syncopes. Boire avant, pendant et après chaque session." },
             ].map((item) => (
               <div key={item.label} style={{
                 display: "flex", alignItems: "center", gap: "8px",
-                padding: "4px 8px", marginBottom: "3px",
+                padding: "3px 8px", marginBottom: "3px",
                 backgroundColor: "#f8fafc", borderRadius: "6px", border: "1px solid #e2e8f0",
               }}>
                 <div style={{ width: "26px", height: "26px", flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
                   {item.svg}
                 </div>
-                <span style={{ fontSize: "10px", color: "#374151", fontWeight: "500", flex: 1 }}>{item.label}</span>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: "10px", color: "#374151", fontWeight: "600" }}>{item.label}</div>
+                  <div style={{ fontSize: "8.5px", color: "#64748b", lineHeight: 1.3, marginTop: "1px" }}>{item.desc}</div>
+                </div>
                 <CheckIcon />
               </div>
             ))}

--- a/src/components/pdf/pages/PDFPageSecuritePortrait.tsx
+++ b/src/components/pdf/pages/PDFPageSecuritePortrait.tsx
@@ -161,7 +161,7 @@ export const PDFPageSecuritePortrait = () => {
               { svg: <IconPalmes />, label: "Palmes" },
               { svg: <IconMasque />, label: "Masque" },
               { svg: <IconTuba />, label: "Tuba" },
-              { svg: <IconCombinaison />, label: "Combinaison néoprène refendu" },
+              { svg: <IconCombinaison />, label: "Combinaison (néoprène refendu recommandé)" },
               { svg: <IconCeinture />, label: "Ceinture de plombs" },
               { svg: <IconGourde />, label: "Gourde d'eau (obligatoire)" },
             ].map((item) => (

--- a/src/components/pdf/pages/PDFPageSecuritePortrait.tsx
+++ b/src/components/pdf/pages/PDFPageSecuritePortrait.tsx
@@ -204,7 +204,8 @@ export const PDFPageSecuritePortrait = () => {
               <div>
                 <div style={{ fontSize: "10px", fontWeight: "800", color: "#dc2626", marginBottom: "3px", textTransform: "uppercase" }}>Règle stricte</div>
                 <div style={{ fontSize: "10px", color: "#7f1d1d", lineHeight: 1.5 }}>
-                  Tout apnéiste ne disposant pas de la liste exhaustive du matériel,{" "}
+                  Pour des raisons de responsabilité de l'association et de l'encadrant,{" "}
+                  tout apnéiste ne disposant pas de la liste exhaustive du matériel,{" "}
                   ou présentant un équipement en mauvais état,{" "}
                   <strong>se verra refuser la sortie en mer par l'encadrant.</strong>
                 </div>

--- a/src/components/pdf/pages/PDFPageSecuritePortrait.tsx
+++ b/src/components/pdf/pages/PDFPageSecuritePortrait.tsx
@@ -1,0 +1,318 @@
+import { ReactNode } from "react";
+import logoTeamOxygen from "@/assets/logo-team-oxygen.webp";
+
+/* ── Equipment SVG icons ── */
+
+const IconPalmes = () => (
+  <svg viewBox="0 0 28 28" width="28" height="28" fill="none">
+    <ellipse cx="8" cy="18" rx="5" ry="9" fill="#0891b2" opacity="0.85" transform="rotate(-15 8 18)" />
+    <rect x="6" y="9" width="4" height="12" rx="2" fill="#0e7490" transform="rotate(-15 8 18)" />
+    <ellipse cx="20" cy="18" rx="5" ry="9" fill="#0891b2" opacity="0.85" transform="rotate(15 20 18)" />
+    <rect x="18" y="9" width="4" height="12" rx="2" fill="#0e7490" transform="rotate(15 20 18)" />
+    <rect x="4" y="21" width="8" height="4" rx="2" fill="#164e63" transform="rotate(-5 8 23)" />
+    <rect x="16" y="21" width="8" height="4" rx="2" fill="#164e63" transform="rotate(5 20 23)" />
+  </svg>
+);
+
+const IconMasque = () => (
+  <svg viewBox="0 0 28 28" width="28" height="28" fill="none">
+    <rect x="3" y="8" width="22" height="14" rx="4" fill="#1e3a5f" />
+    <rect x="4.5" y="9.5" width="8.5" height="11" rx="3" fill="#bae6fd" opacity="0.7" />
+    <rect x="15" y="9.5" width="8.5" height="11" rx="3" fill="#bae6fd" opacity="0.7" />
+    <rect x="12.5" y="12" width="3" height="4" rx="1" fill="#1e3a5f" />
+    <rect x="1" y="13" width="2.5" height="2" rx="1" fill="#374151" />
+    <rect x="24.5" y="13" width="2.5" height="2" rx="1" fill="#374151" />
+    <path d="M3 18 Q14 23 25 18" stroke="#64748b" strokeWidth="1.5" fill="none" />
+  </svg>
+);
+
+const IconTuba = () => (
+  <svg viewBox="0 0 28 28" width="28" height="28" fill="none">
+    <path d="M10 24 Q10 14 16 10 Q19 7 20 4" stroke="#0891b2" strokeWidth="4" strokeLinecap="round" fill="none" />
+    <path d="M10 24 Q10 14 16 10 Q19 7 20 4" stroke="#e0f2fe" strokeWidth="2" strokeLinecap="round" fill="none" opacity="0.5" />
+    <rect x="17" y="2" width="6" height="4" rx="2" fill="#0e7490" />
+    <ellipse cx="10" cy="24" rx="4" ry="3" fill="#1e3a5f" />
+    <ellipse cx="10" cy="24" rx="2.5" ry="1.5" fill="#374151" />
+    <circle cx="13" cy="17" r="1.5" fill="#fbbf24" />
+  </svg>
+);
+
+const IconCombinaison = () => (
+  <svg viewBox="0 0 28 28" width="28" height="28" fill="none">
+    <rect x="8" y="7" width="12" height="13" rx="3" fill="#1e3a5f" />
+    <path d="M8 9 Q3 11 3 16" stroke="#1e3a5f" strokeWidth="4" strokeLinecap="round" fill="none" />
+    <path d="M20 9 Q25 11 25 16" stroke="#1e3a5f" strokeWidth="4" strokeLinecap="round" fill="none" />
+    <path d="M11 20 Q10 25 9 27" stroke="#1e3a5f" strokeWidth="4" strokeLinecap="round" fill="none" />
+    <path d="M17 20 Q18 25 19 27" stroke="#1e3a5f" strokeWidth="4" strokeLinecap="round" fill="none" />
+    <line x1="14" y1="7" x2="14" y2="16" stroke="#0891b2" strokeWidth="1.2" strokeDasharray="1.5 1.5" />
+    <path d="M10 7 Q14 4 18 7" stroke="#0891b2" strokeWidth="1.5" fill="none" />
+    <rect x="8" y="12" width="12" height="2" rx="1" fill="#0891b2" opacity="0.6" />
+  </svg>
+);
+
+const IconCeinture = () => (
+  <svg viewBox="0 0 28 28" width="28" height="28" fill="none">
+    <rect x="2" y="12" width="24" height="4" rx="2" fill="#374151" />
+    <rect x="12" y="10" width="4" height="8" rx="1" fill="#9ca3af" />
+    <rect x="13" y="11" width="2" height="6" rx="0.5" fill="#6b7280" />
+    <rect x="3" y="11" width="5" height="6" rx="1" fill="#4b5563" />
+    <line x1="5.5" y1="11" x2="5.5" y2="17" stroke="#6b7280" strokeWidth="0.8" />
+    <rect x="9" y="11" width="2.5" height="6" rx="1" fill="#4b5563" />
+    <rect x="16.5" y="11" width="2.5" height="6" rx="1" fill="#4b5563" />
+    <rect x="20" y="11" width="5" height="6" rx="1" fill="#4b5563" />
+    <line x1="22.5" y1="11" x2="22.5" y2="17" stroke="#6b7280" strokeWidth="0.8" />
+  </svg>
+);
+
+const IconGourde = () => (
+  <svg viewBox="0 0 28 28" width="28" height="28" fill="none">
+    <rect x="8" y="9" width="12" height="16" rx="4" fill="#0891b2" />
+    <rect x="8" y="16" width="12" height="9" rx="4" fill="#0e7490" />
+    <rect x="11" y="6" width="6" height="4" rx="2" fill="#0e7490" />
+    <rect x="10" y="3" width="8" height="4" rx="2" fill="#1e3a5f" />
+    <path d="M20 12 Q24 14 24 18 Q24 22 20 22" stroke="#0891b2" strokeWidth="2" fill="none" strokeLinecap="round" />
+    <rect x="10" y="17" width="8" height="5" rx="1" fill="white" opacity="0.2" />
+    <rect x="10" y="10" width="3" height="8" rx="1.5" fill="white" opacity="0.2" />
+  </svg>
+);
+
+export const PDFPageSecuritePortrait = () => {
+  return (
+    <div
+      data-pdf-page
+      style={{
+        width: "794px",
+        height: "1123px",
+        backgroundColor: "#ffffff",
+        color: "#1a1a1a",
+        fontFamily: "Inter, system-ui, sans-serif",
+        position: "relative",
+        overflow: "hidden",
+        padding: "28px 36px",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        gap: "9px",
+      }}
+    >
+      {/* Header */}
+      <div style={{
+        background: "linear-gradient(135deg, #0c2340 0%, #1e3a5f 60%, #0891b2 100%)",
+        borderRadius: "12px",
+        padding: "13px 18px",
+        display: "flex",
+        alignItems: "center",
+        gap: "16px",
+        flexShrink: 0,
+      }}>
+        <div style={{
+          backgroundColor: "white",
+          borderRadius: "10px",
+          padding: "6px",
+          flexShrink: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}>
+          <img src={logoTeamOxygen} alt="Team Oxygen" style={{ width: "52px", height: "auto" }} />
+        </div>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: "8px", fontWeight: "700", letterSpacing: "2px", color: "#7dd3fc", textTransform: "uppercase" }}>
+            Fiche Sécurité
+          </div>
+          <div style={{ fontSize: "20px", fontWeight: "800", color: "#ffffff", lineHeight: 1.1, margin: "2px 0" }}>
+            TEAM OXYGEN
+          </div>
+          <div style={{ fontSize: "9px", color: "#bae6fd", fontStyle: "italic" }}>
+            BE AN ECO EXPLORER — Prendre soin de soi, des autres et de la mer
+          </div>
+        </div>
+        <div style={{
+          padding: "6px 12px",
+          backgroundColor: "rgba(255,255,255,0.15)",
+          borderRadius: "8px",
+          textAlign: "center",
+        }}>
+          <div style={{ fontSize: "9px", color: "#7dd3fc", fontWeight: "700" }}>Association</div>
+          <div style={{ fontSize: "9px", color: "#bae6fd" }}>Plongée & Apnée</div>
+          <div style={{ fontSize: "9px", color: "#bae6fd" }}>Martigues-Marseille</div>
+        </div>
+      </div>
+
+      {/* Section 1 */}
+      <SectionCard number="1" title="Prendre soin de soi" subtitle="Sécurité individuelle" color="#0891b2">
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0 20px" }}>
+          <Item color="#0891b2" label="Écoute & modération">Être à l'écoute de soi et raisonnable. Nous sommes notre première sécurité.</Item>
+          <Item color="#0891b2" label="Préparation mentale">Engager la pratique de l'apnée dans un état relaxé.</Item>
+          <Item color="#0891b2" label="Philosophie de pratique">Ne pas rechercher la performance à tout prix — progresser dans le plaisir.</Item>
+          <Item color="#0891b2" label="Hydratation">Bien s'hydrater avant et après chaque plongée.</Item>
+        </div>
+      </SectionCard>
+
+      {/* Section 2 */}
+      <SectionCard number="2" title="Équipement Obligatoire & Check-list Matériel" subtitle="À vérifier avant chaque sortie" color="#dc2626">
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px" }}>
+          {/* Equipment list */}
+          <div>
+            <div style={{ fontSize: "8px", fontWeight: "700", color: "#374151", marginBottom: "5px", textTransform: "uppercase", letterSpacing: "0.5px" }}>
+              Équipement requis par apnéiste
+            </div>
+            {[
+              { svg: <IconPalmes />, label: "Palmes" },
+              { svg: <IconMasque />, label: "Masque" },
+              { svg: <IconTuba />, label: "Tuba" },
+              { svg: <IconCombinaison />, label: "Combinaison néoprène refendu" },
+              { svg: <IconCeinture />, label: "Ceinture de plombs" },
+              { svg: <IconGourde />, label: "Gourde d'eau (obligatoire)" },
+            ].map((item) => (
+              <div key={item.label} style={{
+                display: "flex", alignItems: "center", gap: "8px",
+                padding: "4px 8px", marginBottom: "3px",
+                backgroundColor: "#f8fafc", borderRadius: "6px", border: "1px solid #e2e8f0",
+              }}>
+                <div style={{ width: "26px", height: "26px", flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center" }}>
+                  {item.svg}
+                </div>
+                <span style={{ fontSize: "10px", color: "#374151", fontWeight: "500", flex: 1 }}>{item.label}</span>
+                <CheckIcon />
+              </div>
+            ))}
+          </div>
+
+          {/* Checks + warning */}
+          <div style={{ display: "flex", flexDirection: "column", gap: "7px" }}>
+            <div style={{ fontSize: "9px", fontWeight: "700", color: "#374151", marginBottom: "0px", textTransform: "uppercase", letterSpacing: "0.5px" }}>
+              Vérifications
+            </div>
+            <div style={{ padding: "8px 11px", backgroundColor: "#fef3c7", borderRadius: "7px", border: "1px solid #fcd34d" }}>
+              <div style={{ fontSize: "10px", fontWeight: "700", color: "#92400e", marginBottom: "3px" }}>✓ Check avant départ</div>
+              <div style={{ fontSize: "10px", color: "#78350f" }}>Faire un check matos avant de quitter la maison et d'aller à l'eau.</div>
+            </div>
+            <div style={{ padding: "8px 11px", backgroundColor: "#f0fdf4", borderRadius: "7px", border: "1px solid #86efac" }}>
+              <div style={{ fontSize: "10px", fontWeight: "700", color: "#166534", marginBottom: "3px" }}>✓ Adaptation météo</div>
+              <div style={{ fontSize: "10px", color: "#14532d" }}>Choisir le matériel en fonction des conditions météo et de l'activité.</div>
+            </div>
+            <div style={{
+              padding: "9px 11px", backgroundColor: "#fef2f2",
+              border: "2px solid #dc2626", borderRadius: "8px",
+              display: "flex", alignItems: "flex-start", gap: "8px", flex: 1,
+            }}>
+              <span style={{ fontSize: "18px", flexShrink: 0 }}>⚠️</span>
+              <div>
+                <div style={{ fontSize: "10px", fontWeight: "800", color: "#dc2626", marginBottom: "3px", textTransform: "uppercase" }}>Règle stricte</div>
+                <div style={{ fontSize: "10px", color: "#7f1d1d", lineHeight: 1.5 }}>
+                  En cas de manquement,{" "}
+                  <strong>le refus de sortir en mer sera appliqué immédiatement.</strong>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </SectionCard>
+
+      {/* Sections 3 + 4 side by side */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "10px", flexShrink: 0 }}>
+        <SectionCard number="3" title="Organisation & Ponctualité" subtitle="Respect des engagements" color="#0d9488">
+          <Item color="#0d9488" label="Respect des horaires">Horaires scrupuleusement respectés, avec une marge de sécurité systématique.</Item>
+          <Item color="#0d9488" label="Anticipation">Éviter toute annulation à moins de 24h de la sortie.</Item>
+        </SectionCard>
+
+        <SectionCard number="4" title="Prendre soin de son binôme" subtitle="Sécurité collective" color="#7c3aed">
+          <Item color="#7c3aed" label="Niveau équivalent">Les binômes doivent être de même niveau.</Item>
+          <Item color="#7c3aed" label="Responsabilité">Prendre son rôle aussi sérieusement que ses propres apnées.</Item>
+          <Item color="#7c3aed" label="Communication">Communiquer avant, pendant et après les plongées.</Item>
+          <Item color="#7c3aed" label="Cohésion">Garder un esprit d'équipe et de partage.</Item>
+        </SectionCard>
+      </div>
+
+      {/* Section 5 */}
+      <SectionCard number="5" title="Respect de l'environnement & Encadrement" subtitle="Éco-responsabilité" color="#059669">
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: "0 20px", alignItems: "center" }}>
+          <Item color="#059669" label="Consignes encadrant">Rester vigilant aux dangers liés à la mer et respecter les consignes de l'encadrant.</Item>
+          <Item color="#059669" label="Éco-responsabilité">Respecter la faune et la flore — nous sommes des invités dans leur milieu.</Item>
+          <div style={{
+            padding: "8px 10px",
+            background: "linear-gradient(135deg, #ecfdf5, #d1fae5)",
+            border: "1.5px solid #059669", borderRadius: "7px",
+            display: "flex", alignItems: "center", gap: "8px",
+          }}>
+            <span style={{ fontSize: "16px" }}>🌿</span>
+            <span style={{ fontSize: "10px", fontWeight: "700", color: "#065f46" }}>
+              Zéro déchet · Zéro impact · Maximum de respect
+            </span>
+          </div>
+        </div>
+      </SectionCard>
+
+      {/* Règles binôme */}
+      <div style={{
+        border: "1.5px solid #7c3aed30", borderRadius: "10px", overflow: "hidden", flexShrink: 0,
+      }}>
+        <div style={{ backgroundColor: "#7c3aed", padding: "7px 14px", display: "flex", alignItems: "center", gap: "8px" }}>
+          <span style={{ fontSize: "13px" }}>🤝</span>
+          <div style={{ fontSize: "12px", fontWeight: "700", color: "white" }}>Mes engagements de binôme</div>
+        </div>
+        <div style={{ padding: "10px 12px", display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "7px" }}>
+          {[
+            { icon: "👁️", text: "Je surveille mon binôme en permanence" },
+            { icon: "🚫", text: "Je ne le quitte jamais des yeux en plongée" },
+            { icon: "🤙", text: "Je signale tout inconfort ou malaise" },
+            { icon: "⏱️", text: "Je respecte les temps de surface" },
+            { icon: "🔄", text: "Un plonge, l'autre surveille — j'alterne" },
+            { icon: "📢", text: "Je donne l'alerte sans hésitation" },
+          ].map((rule) => (
+            <div key={rule.text} style={{
+              display: "flex", alignItems: "center", gap: "7px",
+              padding: "6px 9px",
+              backgroundColor: "#faf5ff", borderRadius: "6px", border: "1px solid #e9d5ff",
+            }}>
+              <span style={{ fontSize: "14px", flexShrink: 0 }}>{rule.icon}</span>
+              <span style={{ fontSize: "10px", color: "#374151" }}>{rule.text}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const CheckIcon = () => (
+  <svg style={{ width: "13px", height: "13px", color: "#16a34a", flexShrink: 0 }} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+const SectionCard = ({
+  number, title, subtitle, color, children,
+}: {
+  number: string; title: string; subtitle?: string; color: string; children: ReactNode;
+}) => (
+  <div style={{ border: `1.5px solid ${color}30`, borderRadius: "9px", overflow: "hidden", flexShrink: 0 }}>
+    <div style={{ backgroundColor: color, padding: "6px 12px", display: "flex", alignItems: "center", gap: "9px" }}>
+      <div style={{
+        width: "20px", height: "20px", borderRadius: "50%",
+        backgroundColor: "rgba(255,255,255,0.25)",
+        display: "block",
+        textAlign: "center", lineHeight: "20px",
+        fontSize: "11px", fontWeight: "800", color: "white", flexShrink: 0,
+      }}>
+        {number}
+      </div>
+      <div>
+        <div style={{ fontSize: "12px", fontWeight: "700", color: "white" }}>{title}</div>
+        {subtitle && <div style={{ fontSize: "8px", color: "rgba(255,255,255,0.85)" }}>{subtitle}</div>}
+      </div>
+    </div>
+    <div style={{ padding: "8px 12px" }}>{children}</div>
+  </div>
+);
+
+const Item = ({ label, children, color }: { label: string; children: ReactNode; color: string }) => (
+  <div style={{ marginBottom: "5px", display: "flex", gap: "7px" }}>
+    <div style={{ width: "3px", minWidth: "3px", borderRadius: "2px", backgroundColor: color, marginTop: "3px" }} />
+    <div style={{ lineHeight: 1.45 }}>
+      <span style={{ fontSize: "10px", fontWeight: "700", color: "#1e3a5f" }}>{label} : </span>
+      <span style={{ fontSize: "10px", color: "#374151" }}>{children}</span>
+    </div>
+  </div>
+);

--- a/src/pages/Security.tsx
+++ b/src/pages/Security.tsx
@@ -1,31 +1,13 @@
-import { Shield, Download } from "lucide-react";
+import { Shield } from "lucide-react";
 import Layout from "@/components/layout/Layout";
 import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { toast } from "sonner";
+import { FicheSecuriteGenerator } from "@/components/pdf/FicheSecuriteGenerator";
 
 const Security = () => {
-  const handleDownloadPDF = () => {
-    const link = document.createElement('a');
-    link.href = '/files/Fiche Sécurité  TO2.pdf';
-    link.download = 'Fiche_Securite_TO2.pdf';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    toast.success("Téléchargement de la fiche sécurité...");
-  };
-
-  const securityPages = [
-    { id: 1, image: '/files/security/Fiche sécurité_Page_1.png', title: 'Prévenir' },
-    { id: 2, image: '/files/security/Fiche sécurité_Page_2.png', title: 'Intervenir en profondeur' },
-    { id: 3, image: '/files/security/Fiche sécurité_Page_3.png', title: 'Intervenir en surface' },
-    { id: 4, image: '/files/security/Fiche sécurité_Page_4.png', title: 'Alerter' },
-  ];
-
   return (
     <Layout>
-      <div className="container mx-auto py-8 px-4">
+      <div className="container mx-auto py-8 px-4 max-w-5xl">
         {/* Header */}
         <div className="mb-8">
           <div className="flex items-center justify-between mb-4">
@@ -34,14 +16,11 @@ const Security = () => {
                 <Shield className="h-6 w-6 text-red-600 dark:text-red-400" />
               </div>
               <div>
-                <h1 className="text-3xl font-bold">Sécurité en Apnée</h1>
+                <h1 className="text-3xl font-bold">Fiche Sécurité Team Oxygen</h1>
                 <p className="text-muted-foreground">Consignes essentielles pour pratiquer en toute sécurité</p>
               </div>
             </div>
-            <Button variant="outline" onClick={handleDownloadPDF} className="gap-2">
-              <Download className="h-4 w-4" />
-              Télécharger le PDF
-            </Button>
+            <FicheSecuriteGenerator />
           </div>
           <div className="flex gap-2 flex-wrap">
             <Badge variant="destructive" className="gap-1">
@@ -49,26 +28,176 @@ const Security = () => {
               Lecture obligatoire
             </Badge>
             <Badge variant="secondary">Team Oxygen</Badge>
+            <Badge variant="outline">🌿 Be an Eco Explorer</Badge>
           </div>
         </div>
 
-        {/* Security Pages as Images */}
-        <div className="space-y-8">
-          {securityPages.map((page) => (
-            <Card key={page.id} className="overflow-hidden shadow-lg">
-              <CardContent className="p-0">
-                <img
-                  src={page.image}
-                  alt={`Fiche sécurité - ${page.title}`}
-                  className="w-full h-auto object-contain"
-                  loading="lazy"
-                />
-              </CardContent>
-            </Card>
-          ))}
+        {/* Tagline */}
+        <Card className="mb-6 bg-gradient-to-r from-blue-950 via-blue-900 to-cyan-800 text-white border-0">
+          <CardContent className="pt-5 pb-5 text-center">
+            <p className="text-lg font-semibold italic text-cyan-200">
+              « Prendre soin de soi, des autres et de la mer »
+            </p>
+          </CardContent>
+        </Card>
+
+        {/* Sections */}
+        <div className="space-y-5">
+          <Section
+            number="1"
+            title="Prendre soin de soi"
+            subtitle="Sécurité individuelle"
+            color="blue"
+          >
+            <div className="grid md:grid-cols-2 gap-3">
+              <Item label="Écoute & modération">
+                Être à l'écoute de soi et raisonnable. Nous sommes notre première sécurité.
+              </Item>
+              <Item label="Préparation mentale">
+                Engager la pratique de l'apnée dans un état relaxé.
+              </Item>
+              <Item label="Philosophie de pratique">
+                Ne pas rechercher la performance à tout prix, mais être dans une volonté de progression.
+              </Item>
+              <Item label="Hydratation">
+                Penser à bien s'hydrater avant et après chaque plongée.
+              </Item>
+            </div>
+          </Section>
+
+          <Section
+            number="2"
+            title="Équipement Obligatoire & Check-list Matériel"
+            subtitle="À vérifier avant chaque sortie"
+            color="red"
+          >
+            <div className="grid md:grid-cols-2 gap-4">
+              <div>
+                <p className="text-sm font-semibold text-muted-foreground mb-3 uppercase tracking-wide">
+                  Équipement requis par apnéiste
+                </p>
+                <ul className="space-y-2">
+                  {[
+                    { icon: "🦵", label: "Palmes" },
+                    { icon: "🤿", label: "Masque" },
+                    { icon: "🌊", label: "Tuba" },
+                    { icon: "🩱", label: "Combinaison (néoprène refendu recommandé)" },
+                    { icon: "⚖️", label: "Ceinture de plombs" },
+                    { icon: "💧", label: "Gourde d'eau — obligatoire sur toutes les sorties" },
+                  ].map((item) => (
+                    <li
+                      key={item.label}
+                      className="flex items-center gap-3 p-2 rounded-lg bg-muted/50 text-sm"
+                    >
+                      <span className="text-base">{item.icon}</span>
+                      <span>{item.label}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="space-y-3">
+                <div className="p-3 rounded-lg bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800">
+                  <p className="text-sm font-semibold text-amber-800 dark:text-amber-300 mb-1">
+                    ✓ Check avant départ
+                  </p>
+                  <p className="text-sm text-amber-700 dark:text-amber-400">
+                    Faire un check matos avant de quitter la maison et d'aller à l'eau.
+                  </p>
+                </div>
+                <div className="p-3 rounded-lg bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-800">
+                  <p className="text-sm font-semibold text-green-800 dark:text-green-300 mb-1">
+                    ✓ Adaptation météo
+                  </p>
+                  <p className="text-sm text-green-700 dark:text-green-400">
+                    Choisir le matériel en fonction des conditions météo et de l'activité ciblée.
+                  </p>
+                </div>
+                <div className="p-3 rounded-lg bg-red-50 dark:bg-red-950/30 border-2 border-red-500">
+                  <div className="flex gap-2 items-start">
+                    <span className="text-lg">⚠️</span>
+                    <div>
+                      <p className="text-sm font-bold text-red-700 dark:text-red-400 mb-1">
+                        RÈGLE STRICTE
+                      </p>
+                      <p className="text-sm text-red-700 dark:text-red-400">
+                        En cas de manquement à l'un de ces éléments,{" "}
+                        <strong>le refus de sortir en mer sera appliqué immédiatement.</strong>
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </Section>
+
+          <Section
+            number="3"
+            title="Organisation, Ponctualité & Respect des engagements"
+            color="teal"
+          >
+            <div className="grid md:grid-cols-2 gap-3">
+              <Item label="Respect des horaires">
+                Les horaires de la sortie doivent être scrupuleusement respectés, en intégrant
+                systématiquement une marge de sécurité.
+              </Item>
+              <Item label="Anticipation des annulations">
+                Afin de garantir la bonne organisation et le respect des encadrants, on évite les
+                annulations à moins de 24 heures de la sortie.
+              </Item>
+            </div>
+          </Section>
+
+          <Section
+            number="4"
+            title="Prendre soin de son binôme"
+            subtitle="Sécurité collective"
+            color="purple"
+          >
+            <div className="grid md:grid-cols-2 gap-3">
+              <Item label="Niveau équivalent">
+                Les binômes doivent être de même niveau pour garantir une sécurité optimale.
+              </Item>
+              <Item label="Responsabilité">
+                Prendre son rôle de binôme aussi sérieusement que ses propres apnées.
+              </Item>
+              <Item label="Communication">
+                Bien communiquer avec son binôme — avant, pendant et après les plongées.
+              </Item>
+              <Item label="Cohésion">
+                Garder un esprit d'équipe et de partage en toutes circonstances.
+              </Item>
+            </div>
+          </Section>
+
+          <Section
+            number="5"
+            title="Respect de l'environnement & Encadrement"
+            subtitle="Éco-responsabilité"
+            color="green"
+          >
+            <div className="grid md:grid-cols-2 gap-3">
+              <Item label="Consignes encadrant">
+                Rester vigilant quant aux dangers liés à la mer et bien respecter les consignes de
+                l'encadrant.
+              </Item>
+              <Item label="Éco-responsabilité">
+                Respecter la faune et la flore — nous sommes des invités dans leur milieu.
+              </Item>
+            </div>
+            <div className="mt-4 p-4 rounded-xl bg-gradient-to-r from-emerald-50 to-teal-50 dark:from-emerald-950/30 dark:to-teal-950/30 border border-emerald-200 dark:border-emerald-800 flex items-center gap-4">
+              <span className="text-3xl">🌿</span>
+              <div>
+                <p className="font-bold text-emerald-800 dark:text-emerald-300">BE AN ECO EXPLORER</p>
+                <p className="text-sm text-emerald-700 dark:text-emerald-400">
+                  Chaque plongée est une opportunité de protéger et observer notre environnement marin.
+                  Zéro déchet, zéro impact, maximum de respect.
+                </p>
+              </div>
+            </div>
+          </Section>
         </div>
 
-        {/* Footer avec téléchargement */}
+        {/* Footer download */}
         <Card className="mt-8 bg-gradient-to-r from-blue-50 to-cyan-50 dark:from-blue-950/20 dark:to-cyan-950/20">
           <CardContent className="pt-6">
             <div className="flex flex-col md:flex-row items-center justify-between gap-4">
@@ -81,10 +210,7 @@ const Security = () => {
                   </p>
                 </div>
               </div>
-              <Button onClick={handleDownloadPDF} size="lg" className="gap-2">
-                <Download className="h-4 w-4" />
-                Télécharger le PDF
-              </Button>
+              <FicheSecuriteGenerator />
             </div>
           </CardContent>
         </Card>
@@ -92,5 +218,58 @@ const Security = () => {
     </Layout>
   );
 };
+
+const colorMap: Record<string, string> = {
+  blue: "bg-blue-600",
+  red: "bg-red-600",
+  teal: "bg-teal-600",
+  purple: "bg-purple-700",
+  green: "bg-emerald-600",
+};
+
+const Section = ({
+  number,
+  title,
+  subtitle,
+  color,
+  children,
+}: {
+  number: string;
+  title: string;
+  subtitle?: string;
+  color: string;
+  children: React.ReactNode;
+}) => (
+  <Card className="overflow-hidden">
+    <div className={`${colorMap[color]} px-5 py-3 flex items-center gap-3`}>
+      <div className="w-7 h-7 rounded-full bg-white/20 flex items-center justify-center text-white font-bold text-sm flex-shrink-0">
+        {number}
+      </div>
+      <div>
+        <h2 className="text-white font-bold text-base leading-tight">{title}</h2>
+        {subtitle && (
+          <p className="text-white/80 text-xs">{subtitle}</p>
+        )}
+      </div>
+    </div>
+    <CardContent className="pt-4 pb-5">{children}</CardContent>
+  </Card>
+);
+
+const Item = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex gap-2">
+    <div className="w-1 rounded-full bg-cyan-500 flex-shrink-0 mt-1" />
+    <p className="text-sm">
+      <span className="font-semibold text-foreground">{label} : </span>
+      <span className="text-muted-foreground">{children}</span>
+    </p>
+  </div>
+);
 
 export default Security;

--- a/src/pages/Security.tsx
+++ b/src/pages/Security.tsx
@@ -1,10 +1,8 @@
-import { Shield, Download } from "lucide-react";
+import { Shield } from "lucide-react";
 import Layout from "@/components/layout/Layout";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { toast } from "sonner";
 import { FicheSecuriteGenerator } from "@/components/pdf/FicheSecuriteGenerator";
 
 const securityPages = [
@@ -15,16 +13,6 @@ const securityPages = [
 ];
 
 const Security = () => {
-  const handleDownloadPDF = () => {
-    const link = document.createElement("a");
-    link.href = "/files/Fiche Sécurité  TO2.pdf";
-    link.download = "Fiche_Securite_TO2.pdf";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    toast.success("Téléchargement de la fiche sécurité...");
-  };
-
   return (
     <Layout>
       <div className="container mx-auto py-8 px-4 max-w-5xl">
@@ -58,10 +46,7 @@ const Security = () => {
           {/* Tab 1: original security images */}
           <TabsContent value="securite">
             <div className="flex justify-end mb-4">
-              <Button variant="outline" onClick={handleDownloadPDF} className="gap-2">
-                <Download className="h-4 w-4" />
-                Télécharger la fiche
-              </Button>
+              <FicheSecuriteGenerator />
             </div>
             <div className="space-y-8">
               {securityPages.map((page) => (
@@ -78,10 +63,7 @@ const Security = () => {
               ))}
             </div>
             <div className="mt-6 flex justify-center">
-              <Button variant="outline" onClick={handleDownloadPDF} className="gap-2">
-                <Download className="h-4 w-4" />
-                Télécharger la fiche sécurité
-              </Button>
+              <FicheSecuriteGenerator />
             </div>
           </TabsContent>
 

--- a/src/pages/Security.tsx
+++ b/src/pages/Security.tsx
@@ -78,19 +78,22 @@ const Security = () => {
                 </p>
                 <ul className="space-y-2">
                   {[
-                    { icon: "🦵", label: "Palmes" },
-                    { icon: "🤿", label: "Masque" },
-                    { icon: "🌊", label: "Tuba" },
-                    { icon: "🩱", label: "Combinaison (néoprène refendu recommandé)" },
-                    { icon: "⚖️", label: "Ceinture de plombs" },
-                    { icon: "💧", label: "Gourde d'eau — obligatoire sur toutes les sorties" },
+                    { icon: "🦵", label: "Palmes", desc: "Propulsion efficace et économique — le mouvement de tout le corps préserve l'oxygène." },
+                    { icon: "🤿", label: "Masque", desc: "Vision sous-marine et espace nasal libre pour l'équilibrage des pressions." },
+                    { icon: "🌊", label: "Tuba", desc: "Ventilation en surface sans effort — préserve la capacité pulmonaire avant la plongée." },
+                    { icon: "🩱", label: "Combinaison (néoprène refendu recommandé)", desc: "Protection thermique contre l'hypothermie — le refendu limite les entrées d'eau." },
+                    { icon: "⚖️", label: "Ceinture de plombs", desc: "Compense la flottabilité de la combi — permet une descente fluide et une neutralité à mi-profondeur." },
+                    { icon: "💧", label: "Gourde d'eau — obligatoire sur toutes les sorties", desc: "L'hydratation prévient crampes et syncopes. Boire avant, pendant et après chaque session." },
                   ].map((item) => (
                     <li
                       key={item.label}
-                      className="flex items-center gap-3 p-2 rounded-lg bg-muted/50 text-sm"
+                      className="flex items-start gap-3 p-2 rounded-lg bg-muted/50 text-sm"
                     >
-                      <span className="text-base">{item.icon}</span>
-                      <span>{item.label}</span>
+                      <span className="text-base mt-0.5">{item.icon}</span>
+                      <div>
+                        <span className="font-medium">{item.label}</span>
+                        <p className="text-xs text-muted-foreground mt-0.5">{item.desc}</p>
+                      </div>
                     </li>
                   ))}
                 </ul>

--- a/src/pages/Security.tsx
+++ b/src/pages/Security.tsx
@@ -81,7 +81,7 @@ const Security = () => {
                     { icon: "🦵", label: "Palmes" },
                     { icon: "🤿", label: "Masque" },
                     { icon: "🌊", label: "Tuba" },
-                    { icon: "🩱", label: "Combinaison (néoprène refendu recommandé)" },
+                    { icon: "🩱", label: "Combinaison néoprène refendu" },
                     { icon: "⚖️", label: "Ceinture de plombs" },
                     { icon: "💧", label: "Gourde d'eau — obligatoire sur toutes les sorties" },
                   ].map((item) => (

--- a/src/pages/Security.tsx
+++ b/src/pages/Security.tsx
@@ -3,6 +3,7 @@ import Layout from "@/components/layout/Layout";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { toast } from "sonner";
 import { FicheSecuriteGenerator } from "@/components/pdf/FicheSecuriteGenerator";
 
@@ -28,23 +29,14 @@ const Security = () => {
     <Layout>
       <div className="container mx-auto py-8 px-4 max-w-5xl">
         {/* Header */}
-        <div className="mb-8">
-          <div className="flex items-center justify-between mb-4">
-            <div className="flex items-center gap-3">
-              <div className="h-12 w-12 rounded-full bg-red-100 dark:bg-red-900/20 flex items-center justify-center">
-                <Shield className="h-6 w-6 text-red-600 dark:text-red-400" />
-              </div>
-              <div>
-                <h1 className="text-3xl font-bold">Sécurité en Apnée</h1>
-                <p className="text-muted-foreground">Consignes essentielles pour pratiquer en toute sécurité</p>
-              </div>
+        <div className="mb-6">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="h-12 w-12 rounded-full bg-red-100 dark:bg-red-900/20 flex items-center justify-center">
+              <Shield className="h-6 w-6 text-red-600 dark:text-red-400" />
             </div>
-            <div className="flex items-center gap-2">
-              <Button variant="outline" onClick={handleDownloadPDF} className="gap-2">
-                <Download className="h-4 w-4" />
-                Fiche sécurité
-              </Button>
-              <FicheSecuriteGenerator />
+            <div>
+              <h1 className="text-3xl font-bold">Sécurité en Apnée</h1>
+              <p className="text-muted-foreground">Consignes essentielles pour pratiquer en toute sécurité</p>
             </div>
           </div>
           <div className="flex gap-2 flex-wrap">
@@ -57,186 +49,197 @@ const Security = () => {
           </div>
         </div>
 
-        {/* Original security pages */}
-        <div className="space-y-8 mb-12">
-          {securityPages.map((page) => (
-            <Card key={page.id} className="overflow-hidden shadow-lg">
-              <CardContent className="p-0">
-                <img
-                  src={page.image}
-                  alt={`Fiche sécurité - ${page.title}`}
-                  className="w-full h-auto object-contain"
-                  loading="lazy"
-                />
+        <Tabs defaultValue="securite">
+          <TabsList className="mb-6">
+            <TabsTrigger value="securite">🤿 Sécurité en Apnée</TabsTrigger>
+            <TabsTrigger value="regles">🛡️ Règles Team Oxygen</TabsTrigger>
+          </TabsList>
+
+          {/* Tab 1: original security images */}
+          <TabsContent value="securite">
+            <div className="flex justify-end mb-4">
+              <Button variant="outline" onClick={handleDownloadPDF} className="gap-2">
+                <Download className="h-4 w-4" />
+                Télécharger la fiche
+              </Button>
+            </div>
+            <div className="space-y-8">
+              {securityPages.map((page) => (
+                <Card key={page.id} className="overflow-hidden shadow-lg">
+                  <CardContent className="p-0">
+                    <img
+                      src={page.image}
+                      alt={`Fiche sécurité - ${page.title}`}
+                      className="w-full h-auto object-contain"
+                      loading="lazy"
+                    />
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+            <div className="mt-6 flex justify-center">
+              <Button variant="outline" onClick={handleDownloadPDF} className="gap-2">
+                <Download className="h-4 w-4" />
+                Télécharger la fiche sécurité
+              </Button>
+            </div>
+          </TabsContent>
+
+          {/* Tab 2: Team Oxygen rules */}
+          <TabsContent value="regles">
+            <Card className="mb-6 bg-gradient-to-r from-blue-950 via-blue-900 to-cyan-800 text-white border-0">
+              <CardContent className="pt-5 pb-5 text-center">
+                <p className="text-lg font-semibold italic text-cyan-200">
+                  « Prendre soin de soi, des autres et de la mer »
+                </p>
               </CardContent>
             </Card>
-          ))}
-        </div>
 
-        {/* Divider */}
-        <div className="flex items-center gap-4 mb-8">
-          <div className="flex-1 h-px bg-border" />
-          <div className="flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-blue-950 via-blue-900 to-cyan-800">
-            <Shield className="h-4 w-4 text-cyan-300" />
-            <span className="text-sm font-bold text-white whitespace-nowrap">Règles Team Oxygen</span>
-          </div>
-          <div className="flex-1 h-px bg-border" />
-        </div>
-
-        {/* Tagline */}
-        <Card className="mb-6 bg-gradient-to-r from-blue-950 via-blue-900 to-cyan-800 text-white border-0">
-          <CardContent className="pt-5 pb-5 text-center">
-            <p className="text-lg font-semibold italic text-cyan-200">
-              « Prendre soin de soi, des autres et de la mer »
-            </p>
-          </CardContent>
-        </Card>
-
-        {/* Sections */}
-        <div className="space-y-5">
-          <Section number="1" title="Prendre soin de soi" subtitle="Sécurité individuelle" color="blue">
-            <div className="grid md:grid-cols-2 gap-3">
-              <Item label="Écoute & modération">
-                Être à l'écoute de soi et raisonnable. Nous sommes notre première sécurité.
-              </Item>
-              <Item label="Préparation mentale">
-                Engager la pratique de l'apnée dans un état relaxé.
-              </Item>
-              <Item label="Philosophie de pratique">
-                Ne pas rechercher la performance à tout prix, mais être dans une volonté de progression.
-              </Item>
-              <Item label="Hydratation">
-                Penser à bien s'hydrater avant et après chaque plongée.
-              </Item>
-            </div>
-          </Section>
-
-          <Section number="2" title="Équipement Obligatoire & Check-list Matériel" subtitle="À vérifier avant chaque sortie" color="red">
-            <div className="grid md:grid-cols-2 gap-4">
-              <div>
-                <p className="text-sm font-semibold text-muted-foreground mb-3 uppercase tracking-wide">
-                  Équipement requis par apnéiste
-                </p>
-                <ul className="space-y-2">
-                  {[
-                    { icon: "🦵", label: "Palmes", desc: "Propulsion efficace et économique — le mouvement de tout le corps préserve l'oxygène." },
-                    { icon: "🤿", label: "Masque", desc: "Vision sous-marine et espace nasal libre pour l'équilibrage des pressions." },
-                    { icon: "🌊", label: "Tuba", desc: "Ventilation en surface sans effort — préserve la capacité pulmonaire avant la plongée." },
-                    { icon: "🩱", label: "Combinaison (néoprène refendu recommandé)", desc: "Protection thermique contre l'hypothermie — le refendu limite les entrées d'eau." },
-                    { icon: "⚖️", label: "Ceinture de plombs", desc: "Compense la flottabilité de la combi — permet une descente fluide et une neutralité à mi-profondeur." },
-                    { icon: "💧", label: "Gourde d'eau — obligatoire sur toutes les sorties", desc: "L'hydratation prévient crampes et syncopes. Boire avant, pendant et après chaque session." },
-                  ].map((item) => (
-                    <li key={item.label} className="flex items-start gap-3 p-2 rounded-lg bg-muted/50 text-sm">
-                      <span className="text-base mt-0.5">{item.icon}</span>
-                      <div>
-                        <span className="font-medium">{item.label}</span>
-                        <p className="text-xs text-muted-foreground mt-0.5">{item.desc}</p>
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <div className="space-y-3">
-                <div className="p-3 rounded-lg bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800">
-                  <p className="text-sm font-semibold text-amber-800 dark:text-amber-300 mb-1">✓ Check avant départ</p>
-                  <p className="text-sm text-amber-700 dark:text-amber-400">
-                    Faire un check matos avant de quitter la maison et d'aller à l'eau.
-                  </p>
+            <div className="space-y-5">
+              <Section number="1" title="Prendre soin de soi" subtitle="Sécurité individuelle" color="blue">
+                <div className="grid md:grid-cols-2 gap-3">
+                  <Item label="Écoute & modération">
+                    Être à l'écoute de soi et raisonnable. Nous sommes notre première sécurité.
+                  </Item>
+                  <Item label="Préparation mentale">
+                    Engager la pratique de l'apnée dans un état relaxé.
+                  </Item>
+                  <Item label="Philosophie de pratique">
+                    Ne pas rechercher la performance à tout prix, mais être dans une volonté de progression.
+                  </Item>
+                  <Item label="Hydratation">
+                    Penser à bien s'hydrater avant et après chaque plongée.
+                  </Item>
                 </div>
-                <div className="p-3 rounded-lg bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-800">
-                  <p className="text-sm font-semibold text-green-800 dark:text-green-300 mb-1">✓ Adaptation météo</p>
-                  <p className="text-sm text-green-700 dark:text-green-400">
-                    Choisir le matériel en fonction des conditions météo et de l'activité ciblée.
-                  </p>
-                </div>
-                <div className="p-3 rounded-lg bg-red-50 dark:bg-red-950/30 border-2 border-red-500">
-                  <div className="flex gap-2 items-start">
-                    <span className="text-lg">⚠️</span>
-                    <div>
-                      <p className="text-sm font-bold text-red-700 dark:text-red-400 mb-1">RÈGLE STRICTE</p>
-                      <p className="text-sm text-red-700 dark:text-red-400">
-                        Pour des raisons de responsabilité de l'association et de l'encadrant,
-                        tout apnéiste ne disposant pas de la liste exhaustive du matériel,
-                        ou présentant un équipement en mauvais état,{" "}
-                        <strong>se verra refuser la sortie en mer par l'encadrant.</strong>
+              </Section>
+
+              <Section number="2" title="Équipement Obligatoire & Check-list Matériel" subtitle="À vérifier avant chaque sortie" color="red">
+                <div className="grid md:grid-cols-2 gap-4">
+                  <div>
+                    <p className="text-sm font-semibold text-muted-foreground mb-3 uppercase tracking-wide">
+                      Équipement requis par apnéiste
+                    </p>
+                    <ul className="space-y-2">
+                      {[
+                        { icon: "🦵", label: "Palmes", desc: "Propulsion efficace et économique — le mouvement de tout le corps préserve l'oxygène." },
+                        { icon: "🤿", label: "Masque", desc: "Vision sous-marine et espace nasal libre pour l'équilibrage des pressions." },
+                        { icon: "🌊", label: "Tuba", desc: "Ventilation en surface sans effort — préserve la capacité pulmonaire avant la plongée." },
+                        { icon: "🩱", label: "Combinaison (néoprène refendu recommandé)", desc: "Protection thermique contre l'hypothermie — le refendu limite les entrées d'eau." },
+                        { icon: "⚖️", label: "Ceinture de plombs", desc: "Compense la flottabilité de la combi — permet une descente fluide et une neutralité à mi-profondeur." },
+                        { icon: "💧", label: "Gourde d'eau — obligatoire sur toutes les sorties", desc: "L'hydratation prévient crampes et syncopes. Boire avant, pendant et après chaque session." },
+                      ].map((item) => (
+                        <li key={item.label} className="flex items-start gap-3 p-2 rounded-lg bg-muted/50 text-sm">
+                          <span className="text-base mt-0.5">{item.icon}</span>
+                          <div>
+                            <span className="font-medium">{item.label}</span>
+                            <p className="text-xs text-muted-foreground mt-0.5">{item.desc}</p>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className="space-y-3">
+                    <div className="p-3 rounded-lg bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800">
+                      <p className="text-sm font-semibold text-amber-800 dark:text-amber-300 mb-1">✓ Check avant départ</p>
+                      <p className="text-sm text-amber-700 dark:text-amber-400">
+                        Faire un check matos avant de quitter la maison et d'aller à l'eau.
                       </p>
+                    </div>
+                    <div className="p-3 rounded-lg bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-800">
+                      <p className="text-sm font-semibold text-green-800 dark:text-green-300 mb-1">✓ Adaptation météo</p>
+                      <p className="text-sm text-green-700 dark:text-green-400">
+                        Choisir le matériel en fonction des conditions météo et de l'activité ciblée.
+                      </p>
+                    </div>
+                    <div className="p-3 rounded-lg bg-red-50 dark:bg-red-950/30 border-2 border-red-500">
+                      <div className="flex gap-2 items-start">
+                        <span className="text-lg">⚠️</span>
+                        <div>
+                          <p className="text-sm font-bold text-red-700 dark:text-red-400 mb-1">RÈGLE STRICTE</p>
+                          <p className="text-sm text-red-700 dark:text-red-400">
+                            Pour des raisons de responsabilité de l'association et de l'encadrant,
+                            tout apnéiste ne disposant pas de la liste exhaustive du matériel,
+                            ou présentant un équipement en mauvais état,{" "}
+                            <strong>se verra refuser la sortie en mer par l'encadrant.</strong>
+                          </p>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          </Section>
+              </Section>
 
-          <Section number="3" title="Organisation, Ponctualité & Respect des engagements" color="teal">
-            <div className="grid md:grid-cols-2 gap-3">
-              <Item label="Respect des horaires">
-                Les horaires de la sortie doivent être scrupuleusement respectés, en intégrant
-                systématiquement une marge de sécurité.
-              </Item>
-              <Item label="Anticipation des annulations">
-                Afin de garantir la bonne organisation et le respect des encadrants, on évite les
-                annulations à moins de 24 heures de la sortie.
-              </Item>
-            </div>
-          </Section>
-
-          <Section number="4" title="Prendre soin de son binôme" subtitle="Sécurité collective" color="purple">
-            <div className="grid md:grid-cols-2 gap-3">
-              <Item label="Niveau équivalent">
-                Les binômes doivent être de même niveau pour garantir une sécurité optimale.
-              </Item>
-              <Item label="Responsabilité">
-                Prendre son rôle de binôme aussi sérieusement que ses propres apnées.
-              </Item>
-              <Item label="Communication">
-                Bien communiquer avec son binôme — avant, pendant et après les plongées.
-              </Item>
-              <Item label="Cohésion">
-                Garder un esprit d'équipe et de partage en toutes circonstances.
-              </Item>
-            </div>
-          </Section>
-
-          <Section number="5" title="Respect de l'environnement & Encadrement" subtitle="Éco-responsabilité" color="green">
-            <div className="grid md:grid-cols-2 gap-3">
-              <Item label="Consignes encadrant">
-                Rester vigilant quant aux dangers liés à la mer et bien respecter les consignes de
-                l'encadrant.
-              </Item>
-              <Item label="Éco-responsabilité">
-                Respecter la faune et la flore — nous sommes des invités dans leur milieu.
-              </Item>
-            </div>
-            <div className="mt-4 p-4 rounded-xl bg-gradient-to-r from-emerald-50 to-teal-50 dark:from-emerald-950/30 dark:to-teal-950/30 border border-emerald-200 dark:border-emerald-800 flex items-center gap-4">
-              <span className="text-3xl">🌿</span>
-              <div>
-                <p className="font-bold text-emerald-800 dark:text-emerald-300">BE AN ECO EXPLORER</p>
-                <p className="text-sm text-emerald-700 dark:text-emerald-400">
-                  Chaque plongée est une opportunité de protéger et observer notre environnement marin.
-                  Zéro déchet, zéro impact, maximum de respect.
-                </p>
-              </div>
-            </div>
-          </Section>
-        </div>
-
-        {/* Footer download */}
-        <Card className="mt-8 bg-gradient-to-r from-blue-50 to-cyan-50 dark:from-blue-950/20 dark:to-cyan-950/20">
-          <CardContent className="pt-6">
-            <div className="flex flex-col md:flex-row items-center justify-between gap-4">
-              <div className="flex items-center gap-3">
-                <Shield className="h-8 w-8 text-blue-600" />
-                <div>
-                  <h3 className="font-bold">Fiche sécurité Team Oxygen</h3>
-                  <p className="text-sm text-muted-foreground">
-                    Téléchargez le PDF pour avoir toutes les consignes sous la main
-                  </p>
+              <Section number="3" title="Organisation, Ponctualité & Respect des engagements" color="teal">
+                <div className="grid md:grid-cols-2 gap-3">
+                  <Item label="Respect des horaires">
+                    Les horaires de la sortie doivent être scrupuleusement respectés, en intégrant
+                    systématiquement une marge de sécurité.
+                  </Item>
+                  <Item label="Anticipation des annulations">
+                    Afin de garantir la bonne organisation et le respect des encadrants, on évite les
+                    annulations à moins de 24 heures de la sortie.
+                  </Item>
                 </div>
-              </div>
-              <FicheSecuriteGenerator />
+              </Section>
+
+              <Section number="4" title="Prendre soin de son binôme" subtitle="Sécurité collective" color="purple">
+                <div className="grid md:grid-cols-2 gap-3">
+                  <Item label="Niveau équivalent">
+                    Les binômes doivent être de même niveau pour garantir une sécurité optimale.
+                  </Item>
+                  <Item label="Responsabilité">
+                    Prendre son rôle de binôme aussi sérieusement que ses propres apnées.
+                  </Item>
+                  <Item label="Communication">
+                    Bien communiquer avec son binôme — avant, pendant et après les plongées.
+                  </Item>
+                  <Item label="Cohésion">
+                    Garder un esprit d'équipe et de partage en toutes circonstances.
+                  </Item>
+                </div>
+              </Section>
+
+              <Section number="5" title="Respect de l'environnement & Encadrement" subtitle="Éco-responsabilité" color="green">
+                <div className="grid md:grid-cols-2 gap-3">
+                  <Item label="Consignes encadrant">
+                    Rester vigilant quant aux dangers liés à la mer et bien respecter les consignes de
+                    l'encadrant.
+                  </Item>
+                  <Item label="Éco-responsabilité">
+                    Respecter la faune et la flore — nous sommes des invités dans leur milieu.
+                  </Item>
+                </div>
+                <div className="mt-4 p-4 rounded-xl bg-gradient-to-r from-emerald-50 to-teal-50 dark:from-emerald-950/30 dark:to-teal-950/30 border border-emerald-200 dark:border-emerald-800 flex items-center gap-4">
+                  <span className="text-3xl">🌿</span>
+                  <div>
+                    <p className="font-bold text-emerald-800 dark:text-emerald-300">BE AN ECO EXPLORER</p>
+                    <p className="text-sm text-emerald-700 dark:text-emerald-400">
+                      Chaque plongée est une opportunité de protéger et observer notre environnement marin.
+                      Zéro déchet, zéro impact, maximum de respect.
+                    </p>
+                  </div>
+                </div>
+              </Section>
             </div>
-          </CardContent>
-        </Card>
+
+            <Card className="mt-8 bg-gradient-to-r from-blue-50 to-cyan-50 dark:from-blue-950/20 dark:to-cyan-950/20">
+              <CardContent className="pt-6">
+                <div className="flex flex-col md:flex-row items-center justify-between gap-4">
+                  <div className="flex items-center gap-3">
+                    <Shield className="h-8 w-8 text-blue-600" />
+                    <div>
+                      <h3 className="font-bold">Fiche sécurité Team Oxygen</h3>
+                      <p className="text-sm text-muted-foreground">
+                        Téléchargez le PDF pour avoir toutes les consignes sous la main
+                      </p>
+                    </div>
+                  </div>
+                  <FicheSecuriteGenerator />
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
       </div>
     </Layout>
   );

--- a/src/pages/Security.tsx
+++ b/src/pages/Security.tsx
@@ -1,10 +1,29 @@
-import { Shield } from "lucide-react";
+import { Shield, Download } from "lucide-react";
 import Layout from "@/components/layout/Layout";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 import { FicheSecuriteGenerator } from "@/components/pdf/FicheSecuriteGenerator";
 
+const securityPages = [
+  { id: 1, image: "/files/security/Fiche sécurité_Page_1.png", title: "Prévenir" },
+  { id: 2, image: "/files/security/Fiche sécurité_Page_2.png", title: "Intervenir en profondeur" },
+  { id: 3, image: "/files/security/Fiche sécurité_Page_3.png", title: "Intervenir en surface" },
+  { id: 4, image: "/files/security/Fiche sécurité_Page_4.png", title: "Alerter" },
+];
+
 const Security = () => {
+  const handleDownloadPDF = () => {
+    const link = document.createElement("a");
+    link.href = "/files/Fiche Sécurité  TO2.pdf";
+    link.download = "Fiche_Securite_TO2.pdf";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    toast.success("Téléchargement de la fiche sécurité...");
+  };
+
   return (
     <Layout>
       <div className="container mx-auto py-8 px-4 max-w-5xl">
@@ -16,11 +35,17 @@ const Security = () => {
                 <Shield className="h-6 w-6 text-red-600 dark:text-red-400" />
               </div>
               <div>
-                <h1 className="text-3xl font-bold">Fiche Sécurité Team Oxygen</h1>
+                <h1 className="text-3xl font-bold">Sécurité en Apnée</h1>
                 <p className="text-muted-foreground">Consignes essentielles pour pratiquer en toute sécurité</p>
               </div>
             </div>
-            <FicheSecuriteGenerator />
+            <div className="flex items-center gap-2">
+              <Button variant="outline" onClick={handleDownloadPDF} className="gap-2">
+                <Download className="h-4 w-4" />
+                Fiche sécurité
+              </Button>
+              <FicheSecuriteGenerator />
+            </div>
           </div>
           <div className="flex gap-2 flex-wrap">
             <Badge variant="destructive" className="gap-1">
@@ -30,6 +55,32 @@ const Security = () => {
             <Badge variant="secondary">Team Oxygen</Badge>
             <Badge variant="outline">🌿 Be an Eco Explorer</Badge>
           </div>
+        </div>
+
+        {/* Original security pages */}
+        <div className="space-y-8 mb-12">
+          {securityPages.map((page) => (
+            <Card key={page.id} className="overflow-hidden shadow-lg">
+              <CardContent className="p-0">
+                <img
+                  src={page.image}
+                  alt={`Fiche sécurité - ${page.title}`}
+                  className="w-full h-auto object-contain"
+                  loading="lazy"
+                />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        {/* Divider */}
+        <div className="flex items-center gap-4 mb-8">
+          <div className="flex-1 h-px bg-border" />
+          <div className="flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-blue-950 via-blue-900 to-cyan-800">
+            <Shield className="h-4 w-4 text-cyan-300" />
+            <span className="text-sm font-bold text-white whitespace-nowrap">Règles Team Oxygen</span>
+          </div>
+          <div className="flex-1 h-px bg-border" />
         </div>
 
         {/* Tagline */}
@@ -43,12 +94,7 @@ const Security = () => {
 
         {/* Sections */}
         <div className="space-y-5">
-          <Section
-            number="1"
-            title="Prendre soin de soi"
-            subtitle="Sécurité individuelle"
-            color="blue"
-          >
+          <Section number="1" title="Prendre soin de soi" subtitle="Sécurité individuelle" color="blue">
             <div className="grid md:grid-cols-2 gap-3">
               <Item label="Écoute & modération">
                 Être à l'écoute de soi et raisonnable. Nous sommes notre première sécurité.
@@ -65,12 +111,7 @@ const Security = () => {
             </div>
           </Section>
 
-          <Section
-            number="2"
-            title="Équipement Obligatoire & Check-list Matériel"
-            subtitle="À vérifier avant chaque sortie"
-            color="red"
-          >
+          <Section number="2" title="Équipement Obligatoire & Check-list Matériel" subtitle="À vérifier avant chaque sortie" color="red">
             <div className="grid md:grid-cols-2 gap-4">
               <div>
                 <p className="text-sm font-semibold text-muted-foreground mb-3 uppercase tracking-wide">
@@ -85,10 +126,7 @@ const Security = () => {
                     { icon: "⚖️", label: "Ceinture de plombs", desc: "Compense la flottabilité de la combi — permet une descente fluide et une neutralité à mi-profondeur." },
                     { icon: "💧", label: "Gourde d'eau — obligatoire sur toutes les sorties", desc: "L'hydratation prévient crampes et syncopes. Boire avant, pendant et après chaque session." },
                   ].map((item) => (
-                    <li
-                      key={item.label}
-                      className="flex items-start gap-3 p-2 rounded-lg bg-muted/50 text-sm"
-                    >
+                    <li key={item.label} className="flex items-start gap-3 p-2 rounded-lg bg-muted/50 text-sm">
                       <span className="text-base mt-0.5">{item.icon}</span>
                       <div>
                         <span className="font-medium">{item.label}</span>
@@ -100,17 +138,13 @@ const Security = () => {
               </div>
               <div className="space-y-3">
                 <div className="p-3 rounded-lg bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800">
-                  <p className="text-sm font-semibold text-amber-800 dark:text-amber-300 mb-1">
-                    ✓ Check avant départ
-                  </p>
+                  <p className="text-sm font-semibold text-amber-800 dark:text-amber-300 mb-1">✓ Check avant départ</p>
                   <p className="text-sm text-amber-700 dark:text-amber-400">
                     Faire un check matos avant de quitter la maison et d'aller à l'eau.
                   </p>
                 </div>
                 <div className="p-3 rounded-lg bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-800">
-                  <p className="text-sm font-semibold text-green-800 dark:text-green-300 mb-1">
-                    ✓ Adaptation météo
-                  </p>
+                  <p className="text-sm font-semibold text-green-800 dark:text-green-300 mb-1">✓ Adaptation météo</p>
                   <p className="text-sm text-green-700 dark:text-green-400">
                     Choisir le matériel en fonction des conditions météo et de l'activité ciblée.
                   </p>
@@ -119,9 +153,7 @@ const Security = () => {
                   <div className="flex gap-2 items-start">
                     <span className="text-lg">⚠️</span>
                     <div>
-                      <p className="text-sm font-bold text-red-700 dark:text-red-400 mb-1">
-                        RÈGLE STRICTE
-                      </p>
+                      <p className="text-sm font-bold text-red-700 dark:text-red-400 mb-1">RÈGLE STRICTE</p>
                       <p className="text-sm text-red-700 dark:text-red-400">
                         Pour des raisons de responsabilité de l'association et de l'encadrant,
                         tout apnéiste ne disposant pas de la liste exhaustive du matériel,
@@ -135,11 +167,7 @@ const Security = () => {
             </div>
           </Section>
 
-          <Section
-            number="3"
-            title="Organisation, Ponctualité & Respect des engagements"
-            color="teal"
-          >
+          <Section number="3" title="Organisation, Ponctualité & Respect des engagements" color="teal">
             <div className="grid md:grid-cols-2 gap-3">
               <Item label="Respect des horaires">
                 Les horaires de la sortie doivent être scrupuleusement respectés, en intégrant
@@ -152,12 +180,7 @@ const Security = () => {
             </div>
           </Section>
 
-          <Section
-            number="4"
-            title="Prendre soin de son binôme"
-            subtitle="Sécurité collective"
-            color="purple"
-          >
+          <Section number="4" title="Prendre soin de son binôme" subtitle="Sécurité collective" color="purple">
             <div className="grid md:grid-cols-2 gap-3">
               <Item label="Niveau équivalent">
                 Les binômes doivent être de même niveau pour garantir une sécurité optimale.
@@ -174,12 +197,7 @@ const Security = () => {
             </div>
           </Section>
 
-          <Section
-            number="5"
-            title="Respect de l'environnement & Encadrement"
-            subtitle="Éco-responsabilité"
-            color="green"
-          >
+          <Section number="5" title="Respect de l'environnement & Encadrement" subtitle="Éco-responsabilité" color="green">
             <div className="grid md:grid-cols-2 gap-3">
               <Item label="Consignes encadrant">
                 Rester vigilant quant aux dangers liés à la mer et bien respecter les consignes de
@@ -209,7 +227,7 @@ const Security = () => {
               <div className="flex items-center gap-3">
                 <Shield className="h-8 w-8 text-blue-600" />
                 <div>
-                  <h3 className="font-bold">Fiche sécurité complète</h3>
+                  <h3 className="font-bold">Fiche sécurité Team Oxygen</h3>
                   <p className="text-sm text-muted-foreground">
                     Téléchargez le PDF pour avoir toutes les consignes sous la main
                   </p>
@@ -233,17 +251,9 @@ const colorMap: Record<string, string> = {
 };
 
 const Section = ({
-  number,
-  title,
-  subtitle,
-  color,
-  children,
+  number, title, subtitle, color, children,
 }: {
-  number: string;
-  title: string;
-  subtitle?: string;
-  color: string;
-  children: React.ReactNode;
+  number: string; title: string; subtitle?: string; color: string; children: React.ReactNode;
 }) => (
   <Card className="overflow-hidden">
     <div className={`${colorMap[color]} px-5 py-3 flex items-center gap-3`}>
@@ -252,22 +262,14 @@ const Section = ({
       </div>
       <div>
         <h2 className="text-white font-bold text-base leading-tight">{title}</h2>
-        {subtitle && (
-          <p className="text-white/80 text-xs">{subtitle}</p>
-        )}
+        {subtitle && <p className="text-white/80 text-xs">{subtitle}</p>}
       </div>
     </div>
     <CardContent className="pt-4 pb-5">{children}</CardContent>
   </Card>
 );
 
-const Item = ({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) => (
+const Item = ({ label, children }: { label: string; children: React.ReactNode }) => (
   <div className="flex gap-2">
     <div className="w-1 rounded-full bg-cyan-500 flex-shrink-0 mt-1" />
     <p className="text-sm">

--- a/src/pages/Security.tsx
+++ b/src/pages/Security.tsx
@@ -123,8 +123,10 @@ const Security = () => {
                         RÈGLE STRICTE
                       </p>
                       <p className="text-sm text-red-700 dark:text-red-400">
-                        En cas de manquement à l'un de ces éléments,{" "}
-                        <strong>le refus de sortir en mer sera appliqué immédiatement.</strong>
+                        Pour des raisons de responsabilité de l'association et de l'encadrant,
+                        tout apnéiste ne disposant pas de la liste exhaustive du matériel,
+                        ou présentant un équipement en mauvais état,{" "}
+                        <strong>se verra refuser la sortie en mer par l'encadrant.</strong>
                       </p>
                     </div>
                   </div>

--- a/src/pages/Security.tsx
+++ b/src/pages/Security.tsx
@@ -81,7 +81,7 @@ const Security = () => {
                     { icon: "🦵", label: "Palmes" },
                     { icon: "🤿", label: "Masque" },
                     { icon: "🌊", label: "Tuba" },
-                    { icon: "🩱", label: "Combinaison néoprène refendu" },
+                    { icon: "🩱", label: "Combinaison (néoprène refendu recommandé)" },
                     { icon: "⚖️", label: "Ceinture de plombs" },
                     { icon: "💧", label: "Gourde d'eau — obligatoire sur toutes les sorties" },
                   ].map((item) => (


### PR DESCRIPTION
## Summary

- Split Security page into two tabs: 🤿 Sécurité en Apnée (image pages) / 🛡️ Règles Team Oxygen (5 sections)
- Replace static old PDF download with FicheSecuriteGenerator in both tabs
- Restore original 4-page safety image document alongside new Team Oxygen rules

## Test plan

- [ ] `/security` → tab 1 shows 4 image pages + "Télécharger le PDF" generates new PDF
- [ ] Tab 2 shows 5 Team Oxygen sections + PDF generator in footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)