### PR TITLE
fix(waitlist): comptage fiable de la liste d'attente sur la carte

### DIFF
--- a/src/components/outings/OutingCard.tsx
+++ b/src/components/outings/OutingCard.tsx
@@ -78,7 +78,7 @@ const OutingCard = ({ outing, carpoolInfo }: OutingCardProps) => {
   const isRegistered = !!userReservation;
   const isWaitlisted = userReservation?.status === "en_attente";
   const spotsLeft = outing.max_participants - currentParticipants;
-  const waitlistCount = outing.reservations?.filter((r) => r.status === "en_attente").length ?? 0;
+  const waitlistCount = outing.waitlist_count ?? 0;
   const isPOSSLocked = outing.is_poss_locked === true;
 
   const Icon = typeIcons[outing.outing_type];

--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -59,6 +59,7 @@ export interface Outing {
   dive_mode?: "boat" | "shore" | null;
   boat_id?: string | null;
   confirmed_count?: number; // Real count from SECURITY DEFINER function
+  waitlist_count?: number; // Real waitlist count from SECURITY DEFINER function
   co_instructors?: CoInstructor[];
   organizer?: {
     first_name: string;
@@ -128,6 +129,9 @@ export const useOutings = (typeFilter?: OutingType | null) => {
           const { data: countData } = await supabase
             .rpc('get_outing_confirmed_count', { outing_uuid: outing.id });
 
+          const { data: waitlistData } = await supabase
+            .rpc('get_outing_waitlist_count', { outing_uuid: outing.id });
+
           // Fetch organizer max depths and max participants if organizer has apnea_level
           let maxDepthEaa = null;
           let maxDepthEao = null;
@@ -150,6 +154,7 @@ export const useOutings = (typeFilter?: OutingType | null) => {
           return {
             ...outing,
             confirmed_count: countData ?? 0,
+            waitlist_count: waitlistData ?? 0,
             organizer_max_depth_eaa: maxDepthEaa,
             organizer_max_depth_eao: maxDepthEao,
             organizer_max_participants: maxParticipants,

--- a/supabase/migrations/20260601140000_get_outing_waitlist_count.sql
+++ b/supabase/migrations/20260601140000_get_outing_waitlist_count.sql
@@ -1,0 +1,15 @@
+-- Comptage fiable de la liste d'attente (bypass RLS), comme get_outing_confirmed_count.
+-- Le tableau reservations intégré côté client est filtré par RLS, donc on ne peut
+-- pas compter les en_attente des autres membres de façon fiable depuis le front.
+CREATE OR REPLACE FUNCTION public.get_outing_waitlist_count(outing_uuid uuid)
+RETURNS integer
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COUNT(*)::integer
+  FROM public.reservations
+  WHERE outing_id = outing_uuid
+    AND status = 'en_attente'
+$$;


### PR DESCRIPTION
## Bug

La carte de sortie affichait « (1 en liste d'attente) » au lieu de 2. Le compteur était calculé depuis le tableau `reservations` intégré, filtré par RLS → sous-comptage des inscriptions des autres membres.

## Correctif

Nouvelle fonction `get_outing_waitlist_count` (`SECURITY DEFINER`, comme `get_outing_confirmed_count`) + utilisée dans `useOutings`/`OutingCard`.

Migration déjà appliquée en prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)