### PR TITLE
fix(admin): cascade member deletion + tolerate orphan profiles

### DIFF
--- a/supabase/functions/delete-user/index.ts
+++ b/supabase/functions/delete-user/index.ts
@@ -77,8 +77,34 @@ serve(async (req) => {
       });
     }
 
+    // Cascade-delete all data linked to this member. Tables reference public.profiles
+    // (not auth.users) with NO ACTION, so we must remove child rows explicitly and in
+    // dependency order. Outings and equipment_inventory cascade to their own children.
+    const steps: Array<[string, Promise<{ error: unknown }>]> = [
+      ["reservations", supabaseAdmin.from("reservations").delete().eq("user_id", userId)],
+      ["outings", supabaseAdmin.from("outings").delete().eq("organizer_id", userId)],
+      ["equipment_inventory", supabaseAdmin.from("equipment_inventory").delete().eq("owner_id", userId)],
+      ["equipment_history.created_by", supabaseAdmin.from("equipment_history").delete().eq("created_by", userId)],
+      ["equipment_history.from_user_id", supabaseAdmin.from("equipment_history").delete().eq("from_user_id", userId)],
+      ["equipment_history.to_user_id", supabaseAdmin.from("equipment_history").delete().eq("to_user_id", userId)],
+      ["user_roles", supabaseAdmin.from("user_roles").delete().eq("user_id", userId)],
+      ["profiles", supabaseAdmin.from("profiles").delete().eq("id", userId)],
+    ];
+
+    for (const [name, query] of steps) {
+      const { error } = await query;
+      if (error) throw new Error(`Echec suppression ${name}: ${(error as { message?: string }).message ?? error}`);
+    }
+
+    // Remove the auth account last. Tolerate "user not found" so orphan profiles
+    // (no matching auth.users row) can still be cleaned up without erroring.
     const { error: deleteError } = await supabaseAdmin.auth.admin.deleteUser(userId);
-    if (deleteError) throw deleteError;
+    if (deleteError) {
+      const msg = (deleteError as { message?: string; status?: number }).message ?? "";
+      const status = (deleteError as { status?: number }).status;
+      const notFound = status === 404 || /not found/i.test(msg);
+      if (!notFound) throw deleteError;
+    }
 
     return new Response(JSON.stringify({ success: true }), {
       status: 200,


### PR DESCRIPTION
## Problème
Au lancement test club, supprimer un compte depuis **Administration → Comptes App** affichait `Edge Function returned a non-2xx status code`.

## Cause
La liste vient de la table `profiles`. Certains profils n'ont **pas** de compte `auth.users` correspondant (orphelins) — l'ancienne function supprimait seulement le compte auth, jamais le profil (aucune FK ne les lie). Cliquer corbeille sur un orphelin → GoTrue renvoie `404 User not found` → la function jette → 500.

Confirmé via logs auth : `404: User not found` ×3.

## Correctif
La function `delete-user` :
- supprime explicitement toutes les lignes référençant `public.profiles` dans l'ordre des dépendances (`reservations`, `outings`, `equipment_inventory`, `equipment_history`, `user_roles`, `profiles`) — ces FK sont en `NO ACTION` donc pas de cascade auto. `outings` et `equipment_inventory` cascadent vers leurs enfants.
- tolère un `404 user not found` sur `auth.admin.deleteUser` pour nettoyer les profils orphelins.

Comportement choisi : **suppression cascade complète** du membre et de ses données.

## Déploiement
- Edge function déployée (v4) sur le projet Supabase.
- 2 profils orphelins existants nettoyés (Karim Massilia A0003, karim Saari A0035).

🤖 Generated with [Claude Code](https://claude.com/claude-code)