### PR TITLE
feat(admin): suivi des inscriptions (Comptes App + Fichier Adhérents)

### DIFF
--- a/src/components/admin/ClubMembersDirectory.tsx
+++ b/src/components/admin/ClubMembersDirectory.tsx
@@ -178,6 +178,7 @@ const ClubMembersDirectory = () => {
   const [apneaLevelOpen, setApneaLevelOpen] = useState(false);
   const [filterEncadrant, setFilterEncadrant] = useState(false);
   const [filterIncomplete, setFilterIncomplete] = useState(false);
+  const [filterNotRegistered, setFilterNotRegistered] = useState(false);
   const [purgeConfirmOpen, setPurgeConfirmOpen] = useState(false);
 
   // Identity form data (stored in club_members_directory)
@@ -636,6 +637,11 @@ const ClubMembersDirectory = () => {
         if (isMemberDossierComplete(member.id)) return false;
       }
 
+      // Filter adhérents without an app account only
+      if (filterNotRegistered) {
+        if (isEmailRegistered(member.email)) return false;
+      }
+
       return true;
     }) || [];
 
@@ -676,7 +682,7 @@ const ClubMembersDirectory = () => {
     });
 
     return result;
-  }, [members, searchTerm, sortField, sortDirection, statuses, filterEncadrant, filterIncomplete, apneaLevelCodes]);
+  }, [members, searchTerm, sortField, sortDirection, statuses, filterEncadrant, filterIncomplete, filterNotRegistered, apneaLevelCodes]);
 
   const getRowClassName = (member: ClubMember) => {
     if (isMemberDossierComplete(member.id)) return "bg-green-50 dark:bg-green-950/20";
@@ -779,6 +785,15 @@ const ClubMembersDirectory = () => {
                 <AlertCircle className="h-4 w-4 mr-1" />
                 Incomplets
               </Button>
+              <Button
+                onClick={() => setFilterNotRegistered(!filterNotRegistered)}
+                variant={filterNotRegistered ? "default" : "outline"}
+                size="sm"
+                title="Filtrer les adhérents sans compte app"
+              >
+                <Mail className="h-4 w-4 mr-1" />
+                Non inscrits
+              </Button>
             </div>
           </div>
           <div className="flex flex-col sm:flex-row gap-3">
@@ -820,7 +835,7 @@ const ClubMembersDirectory = () => {
         {membersWithStatus.length > 0 && (
           <div className="flex flex-wrap gap-3 mb-4 text-sm">
             <Badge variant="secondary" className="text-xs">
-              {(filterEncadrant || filterIncomplete) ? `${filteredCount} / ${totalCount}` : totalCount} adhérents
+              {(filterEncadrant || filterIncomplete || filterNotRegistered) ? `${filteredCount} / ${totalCount}` : totalCount} adhérents
             </Badge>
             <Badge variant="secondary" className={cn("text-xs", filterEncadrant && "bg-primary text-primary-foreground")}>
               <GraduationCap className="h-3 w-3 mr-1" />
@@ -835,6 +850,14 @@ const ClubMembersDirectory = () => {
             </Badge>
             <Badge variant="secondary" className="text-xs text-green-600">
               {membersWithStatus.filter((m) => isEmailRegistered(m.email)).length} inscrits app
+            </Badge>
+            <Badge
+              variant="secondary"
+              className={cn("text-xs cursor-pointer text-muted-foreground", filterNotRegistered && "bg-primary text-primary-foreground")}
+              onClick={() => setFilterNotRegistered(!filterNotRegistered)}
+            >
+              <Mail className="h-3 w-3 mr-1" />
+              {membersWithStatus.filter((m) => !isEmailRegistered(m.email)).length} non inscrits
             </Badge>
           </div>
         )}

--- a/src/components/admin/MemberManager.tsx
+++ b/src/components/admin/MemberManager.tsx
@@ -11,6 +11,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { useClubMembersDirectory } from "@/hooks/useClubMembersDirectory";
 
 interface Profile {
   id: string;
@@ -107,6 +108,19 @@ const MemberManager = () => {
     },
   });
 
+  const { members: adherents } = useClubMembersDirectory();
+
+  // Inscription progress: how many adhérents (fichier) already have an app account (profile).
+  const registeredEmailSet = new Set(
+    (profiles ?? []).map((p) => p.email?.toLowerCase()).filter(Boolean)
+  );
+  const totalAdherents = adherents?.length ?? 0;
+  const totalComptes = profiles?.length ?? 0;
+  const inscrits = (adherents ?? []).filter((m) =>
+    registeredEmailSet.has(m.email?.toLowerCase())
+  ).length;
+  const progressPct = totalAdherents > 0 ? Math.round((inscrits / totalAdherents) * 100) : 0;
+
   const isUserAdmin = (userId: string) => {
     return userRoles?.some((role) => role.user_id === userId && role.role === "admin");
   };
@@ -126,6 +140,26 @@ const MemberManager = () => {
         <p className="text-sm text-muted-foreground">Gestion des utilisateurs inscrits et de leurs rôles</p>
       </CardHeader>
       <CardContent>
+        {/* Avancement des inscriptions : comptes app vs fichier adhérents */}
+        <div className="mb-4 rounded-lg border border-border bg-muted/30 p-4">
+          <div className="flex items-baseline justify-between gap-2">
+            <span className="text-sm font-medium text-foreground">Avancement des inscriptions</span>
+            <span className="text-sm font-semibold text-primary">
+              {inscrits} / {totalAdherents} adhérents
+            </span>
+          </div>
+          <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-primary transition-all"
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
+          <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
+            <span>{progressPct}% des adhérents ont créé leur compte</span>
+            <span>{totalComptes} comptes app</span>
+          </div>
+        </div>
+
         <div className="mb-4">
           <div className="relative">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />


### PR DESCRIPTION
## Objectif
Suivre l'avancement des inscriptions à l'app pendant le lancement club.

## Ajouts
**Écran Comptes App** — barre de synthèse en haut :
- `X / Y adhérents` ont créé leur compte + barre de progression + % + total comptes app.

**Écran Fichier Adhérents** — filtre des non-inscrits :
- Bouton **"Non inscrits"** (à côté de Encadrants / Incomplets) → n'affiche que les adhérents sans compte app.
- Badge **"N non inscrits"** cliquable (toggle le même filtre).
- Pratique pour cibler qui relancer / inviter.

Croisement `club_members_directory` ↔ `profiles` par email (minuscules), via le hook existant `useClubMembersDirectory` / `isEmailRegistered`.

## Vérif
- Compile sans erreur (pas d'overlay Vite, HMR OK), aucune erreur TS introduite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)