### PR TITLE
feat(admin): trier Comptes App par ordre d'inscription

### DIFF
--- a/src/components/admin/MemberManager.tsx
+++ b/src/components/admin/MemberManager.tsx
@@ -39,8 +39,9 @@ const MemberManager = () => {
     queryFn: async () => {
       const { data, error } = await supabase
         .from("profiles")
+        // Tri par ordre d'inscription sur l'app : les comptes les plus récents en premier.
         .select("*")
-        .order("last_name", { ascending: true });
+        .order("created_at", { ascending: false });
 
       if (error) throw error;
       return data as Profile[];


### PR DESCRIPTION
## Changement
La liste **Comptes App** était triée par nom de famille. Désormais triée par **date d'inscription sur l'app** (`profiles.created_at`), plus récents en haut.

Permet de voir d'un coup les dernières inscriptions pendant le lancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)