### PR TITLE
fix(layout): mobile nav no longer clips first items

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -119,33 +119,35 @@ const Header = () => {
       {user && (
         <nav
           ref={mobileNavRef}
-          className="flex justify-center gap-1 border-t border-white/5 p-2 lg:hidden overflow-x-auto"
+          className="border-t border-white/5 p-2 lg:hidden overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           style={{ background: "rgba(1,12,28,0.95)" }}
         >
-          {navItems.map(({ to, label, icon: Icon }) => (
-            <Link key={to} to={to}>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={cn(
-                  "gap-1.5 text-xs whitespace-nowrap text-white/70 hover:text-white hover:bg-white/10",
-                  isActive(to) && "bg-white/15 text-white"
-                )}
-              >
-                <Icon className="h-4 w-4" />
-                {label}
-              </Button>
-            </Link>
-          ))}
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={signOut}
-            className="gap-1.5 whitespace-nowrap text-xs text-red-300 hover:bg-red-500/15 hover:text-red-200"
-          >
-            <LogOut className="h-4 w-4" />
-            Déconnexion
-          </Button>
+          <div className="flex w-max mx-auto gap-1">
+            {navItems.map(({ to, label, icon: Icon }) => (
+              <Link key={to} to={to}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    "gap-1.5 text-xs whitespace-nowrap text-white/70 hover:text-white hover:bg-white/10",
+                    isActive(to) && "bg-white/15 text-white"
+                  )}
+                >
+                  <Icon className="h-4 w-4" />
+                  {label}
+                </Button>
+              </Link>
+            ))}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={signOut}
+              className="gap-1.5 whitespace-nowrap text-xs text-red-300 hover:bg-red-500/15 hover:text-red-200"
+            >
+              <LogOut className="h-4 w-4" />
+              Déconnexion
+            </Button>
+          </div>
         </nav>
       )}
     </header>


### PR DESCRIPTION
## Problem
Sur mobile, le menu de navigation en haut était **coupé** : les premiers boutons (à gauche) étaient inaccessibles.

## Cause
`<nav>` utilisait `flex justify-center` + `overflow-x-auto`. Quand le contenu déborde, `justify-center` pousse le contenu hors des **deux** bords et le navigateur ne peut pas scroller jusqu'au début → premiers items clippés/inaccessibles. Piège flexbox classique.

## Fix
Items déplacés dans un conteneur interne `flex w-max mx-auto` à l'intérieur du conteneur scrollable. Centré quand ça rentre, scrollable depuis le début quand ça déborde. Scrollbar masquée pour la propreté.

## Vérification
Test DOM à 375px de large (contenu débordant) :

| | scroll au début | premier item clippé |
|---|---|---|
| Avant (`justify-center`) | bloqué | ❌ oui — inaccessible |
| Après (`w-max mx-auto`) | OK | ✅ non |

`npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)