### PR TITLE
Dashboard Power BI — schéma en étoile + validation dates + vue membre

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,8 @@
       "Bash(npm install qrcode.react)",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__execute_sql",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__get_project",
-      "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__deploy_edge_function"
+      "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__deploy_edge_function",
+      "mcp__Supabase__apply_migration"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,8 @@
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__execute_sql",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__get_project",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__deploy_edge_function",
-      "mcp__Supabase__apply_migration"
+      "mcp__Supabase__apply_migration",
+      "mcp__Supabase__execute_sql"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Club management application for **Team Oxygen**, an eco-friendly diving and free
 - **Maps:** Leaflet
 - **Charts:** Recharts
 - **PDF:** jsPDF + html2canvas
-- **Deployment:** Netlify
+- **Deployment:** Vercel
 
 ## Commands
 
@@ -108,4 +108,4 @@ VITE_SUPABASE_URL           # Supabase API URL
 - Project was scaffolded with **Lovable AI** -- `lovable-tagger` Vite plugin is present and should remain.
 - The `types.ts` file is auto-generated and nearly 1000 lines. Never edit it manually.
 - Edge functions use Deno imports (URL-based), not npm.
-- Netlify handles SPA routing via `[[redirects]]` in `netlify.toml`.
+- Déploiement via **Vercel** (pas Netlify) — chaque merge sur `main` déclenche un déploiement automatique.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { ViewModeProvider } from "@/contexts/ViewModeContext";
 import Index from "./pages/Index";
 import Auth from "./pages/Auth";
 import Reservations from "./pages/Reservations";
@@ -32,6 +33,7 @@ const queryClient = new QueryClient();
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <AuthProvider>
+      <ViewModeProvider>
       <TooltipProvider>
         <Toaster />
         <Sonner />
@@ -62,6 +64,7 @@ const App = () => (
           </Routes>
         </BrowserRouter>
       </TooltipProvider>
+      </ViewModeProvider>
     </AuthProvider>
   </QueryClientProvider>
 );

--- a/src/components/admin/CreateOutingForm.tsx
+++ b/src/components/admin/CreateOutingForm.tsx
@@ -29,7 +29,7 @@ import { toast } from "sonner";
 const outingSchema = z.object({
   title: z.string().min(3, "Le titre doit faire au moins 3 caractères").max(100),
   description: z.string().max(500).optional(),
-  date: z.date({ required_error: "La date est requise" }),
+  date: z.date({ required_error: "La date est requise" }).max(new Date("2030-12-31"), "La date ne peut pas dépasser le 31/12/2030"),
   startTime: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/, "Format invalide (HH:MM)"),
   prepDuration: z.number().min(0).max(180),
   sessionDuration: z.number().min(15).max(480),
@@ -343,7 +343,8 @@ const CreateOutingForm = ({ prefilledLocationId, prefilledLocationName, onClose 
                           disabled={(date) => {
                             const today = new Date();
                             today.setHours(0, 0, 0, 0);
-                            return date < today;
+                            const maxDate = new Date("2030-12-31");
+                            return date < today || date > maxDate;
                           }}
                           initialFocus
                           className="pointer-events-auto"

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { Waves, Calendar, User, Settings, LogOut, Image, FileText, MapIcon, CloudSun, Package, Users, Shield } from "lucide-react";
+import { Waves, Calendar, User, Settings, LogOut, Image, FileText, MapIcon, CloudSun, Package, Users, Shield, Eye, EyeOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUserRole } from "@/hooks/useUserRole";
 import { useIsCurrentUserEncadrant } from "@/hooks/useIsCurrentUserEncadrant";
+import { useViewMode } from "@/contexts/ViewModeContext";
 import { cn } from "@/lib/utils";
 import logoTeamOxygen from "@/assets/logo-team-oxygen.webp";
 
@@ -13,11 +14,16 @@ const Header = () => {
   const { user, signOut } = useAuth();
   const { isAdmin, isOrganizer } = useUserRole();
   const { data: isEncadrantFromDirectory } = useIsCurrentUserEncadrant();
+  const { isMemberPreview, toggleMemberPreview } = useViewMode();
 
   const mobileNavRef = useRef<HTMLElement | null>(null);
 
   // Determine if user is an encadrant (either from directory or has organizer role)
-  const isEncadrant = isOrganizer || isEncadrantFromDirectory;
+  const realIsEncadrant = isOrganizer || isEncadrantFromDirectory;
+  // In member preview mode, override encadrant/organizer flags for nav display
+  const isEncadrant = isMemberPreview ? false : realIsEncadrant;
+  const effectiveIsOrganizer = isMemberPreview ? false : isOrganizer;
+  const canTogglePreview = realIsEncadrant || isAdmin;
 
   const navItems = useMemo(() => {
     const items = [
@@ -38,7 +44,7 @@ const Header = () => {
       items.push({ to: "/equipment", label: "Matériel", icon: Package });
     }
 
-    if (isOrganizer) {
+    if (effectiveIsOrganizer) {
       items.push({ to: "/mes-sorties", label: "Mes Sorties", icon: Calendar });
       items.push({ to: "/archives", label: "Archives", icon: FileText });
     }
@@ -50,12 +56,12 @@ const Header = () => {
     }
 
     return items;
-  }, [isOrganizer, isAdmin, isEncadrant]);
+  }, [effectiveIsOrganizer, isAdmin, isEncadrant]);
 
   // Reset mobile nav scroll when user/role changes
   useEffect(() => {
     mobileNavRef.current?.scrollTo({ left: 0, behavior: "auto" });
-  }, [user?.id, isOrganizer, isAdmin, isEncadrant]);
+  }, [user?.id, effectiveIsOrganizer, isAdmin, isEncadrant]);
 
   const isActive = (path: string) => location.pathname === path;
 
@@ -94,6 +100,23 @@ const Header = () => {
         <div className="flex flex-shrink-0 items-center gap-3">
           {user ? (
             <>
+              {canTogglePreview && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={toggleMemberPreview}
+                  title={isMemberPreview ? "Repasser en vue encadrant" : "Simuler vue membre"}
+                  className={cn(
+                    "gap-2 text-xs hidden lg:flex",
+                    isMemberPreview
+                      ? "text-amber-300 hover:text-amber-200 hover:bg-amber-500/15 ring-1 ring-amber-400/40"
+                      : "text-white/40 hover:text-white/70 hover:bg-white/10"
+                  )}
+                >
+                  {isMemberPreview ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  {isMemberPreview ? "Vue membre" : "Vue membre"}
+                </Button>
+              )}
               <Link to="/profile">
                 <Button variant="ghost" size="icon" className="rounded-full text-white/70 hover:text-white hover:bg-white/10">
                   <User className="h-5 w-5" />

--- a/src/components/outings/EditOutingDialog.tsx
+++ b/src/components/outings/EditOutingDialog.tsx
@@ -27,7 +27,7 @@ import { cn } from "@/lib/utils";
 const editOutingSchema = z.object({
   title: z.string().min(3, "Le titre doit faire au moins 3 caractères").max(100),
   description: z.string().max(500).optional(),
-  date: z.date({ required_error: "La date est requise" }),
+  date: z.date({ required_error: "La date est requise" }).max(new Date("2030-12-31"), "La date ne peut pas dépasser le 31/12/2030"),
   startTime: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/, "Format invalide (HH:MM)"),
   endTime: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/, "Format invalide (HH:MM)").optional(),
   waterEntryTime: z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/, "Format invalide (HH:MM)").optional(),
@@ -213,6 +213,7 @@ const EditOutingDialog = ({ outing }: EditOutingDialogProps) => {
                             field.onChange(date);
                             setIsDateOpen(false);
                           }}
+                          disabled={(date) => date > new Date("2030-12-31")}
                           initialFocus
                           className="pointer-events-auto"
                         />

--- a/src/components/outings/HistoricalOutingForm.tsx
+++ b/src/components/outings/HistoricalOutingForm.tsx
@@ -23,7 +23,7 @@ import { useCreateHistoricalOuting } from "@/hooks/useCreateHistoricalOuting";
 import { cn } from "@/lib/utils";
 
 const historicalOutingSchema = z.object({
-  date: z.date({ required_error: "La date est requise" }),
+  date: z.date({ required_error: "La date est requise" }).max(new Date("2030-12-31"), "La date ne peut pas dépasser le 31/12/2030"),
   location_id: z.string().optional(),
   location: z.string().min(3, "Le lieu doit faire au moins 3 caractères"),
   outing_type: z.enum(["Fosse", "Mer", "Piscine", "Étang", "Dépollution"]),

--- a/src/contexts/ViewModeContext.tsx
+++ b/src/contexts/ViewModeContext.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface ViewModeContextType {
+  isMemberPreview: boolean;
+  toggleMemberPreview: () => void;
+}
+
+const ViewModeContext = createContext<ViewModeContextType>({
+  isMemberPreview: false,
+  toggleMemberPreview: () => {},
+});
+
+export const ViewModeProvider = ({ children }: { children: ReactNode }) => {
+  const [isMemberPreview, setIsMemberPreview] = useState(
+    () => sessionStorage.getItem("memberPreview") === "true"
+  );
+
+  const toggleMemberPreview = () => {
+    setIsMemberPreview((prev) => {
+      const next = !prev;
+      sessionStorage.setItem("memberPreview", String(next));
+      return next;
+    });
+  };
+
+  return (
+    <ViewModeContext.Provider value={{ isMemberPreview, toggleMemberPreview }}>
+      {children}
+    </ViewModeContext.Provider>
+  );
+};
+
+export const useViewMode = () => useContext(ViewModeContext);


### PR DESCRIPTION
## Résumé

### Validation des dates de sortie (31/12/2030)
- Ajout `.max()` Zod + `disabled` calendrier UI dans les 3 formulaires (`CreateOutingForm`, `EditOutingDialog`, `HistoricalOutingForm`)
- Contrainte `CHECK` en base : `outings.date_time <= '2030-12-31 23:59:59+00'`

### Schéma en étoile Power BI
- Création de la table `dim_saison` (2020→2030, saison courante automatique)
- Ajout de `saison_id` calculé dans `fait_participation` et `fait_mouvement_equipement`
- Renommage `saison` → `saison_id` dans `fait_adhesion` (cohérence FK)
- Enrichissement de `dim_membre` avec `est_membre_actif`, `niveau_apnee_saison_courante`, `est_encadrant_saison_courante`, `role_bureau_saison_courante`

### Toggle "Vue membre" (encadrants/admins)
- Nouveau contexte `ViewModeContext` avec persistance `sessionStorage`
- Bouton dans le Header visible uniquement pour les encadrants/admins
- Simule la navigation d'un membre classique sans modifier les droits réels

## Test plan
- [ ] Vérifier que la création d'une sortie au-delà du 31/12/2030 est bloquée (formulaire + message d'erreur)
- [ ] Vérifier que le calendrier UI grise les dates > 31/12/2030
- [ ] En tant qu'encadrant, activer le toggle "Vue membre" → Matériel/Mes Sorties/Archives disparaissent, Souvenirs/Sécurité apparaissent
- [ ] Désactiver le toggle → retour à la vue encadrant
- [ ] Vérifier que le toggle se réinitialise après déconnexion/reconnexion

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHpgfwG9EpvvtzrcSFw3cJ)_