### PR TITLE
Corrige la déformation des photos dans les avatars

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,8 +25,7 @@
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__execute_sql",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__get_project",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__deploy_edge_function",
-      "mcp__Supabase__apply_migration",
-      "mcp__Supabase__execute_sql"
+      "mcp__Supabase__apply_migration"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,8 @@
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__execute_sql",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__get_project",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__deploy_edge_function",
-      "mcp__Supabase__apply_migration"
+      "mcp__Supabase__apply_migration",
+      "mcp__Supabase__execute_sql"
     ]
   }
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -103,18 +103,17 @@ const Header = () => {
               {canTogglePreview && (
                 <Button
                   variant="ghost"
-                  size="sm"
+                  size="icon"
                   onClick={toggleMemberPreview}
                   title={isMemberPreview ? "Repasser en vue encadrant" : "Simuler vue membre"}
                   className={cn(
-                    "gap-2 text-xs hidden lg:flex",
+                    "rounded-full hidden lg:flex",
                     isMemberPreview
                       ? "text-amber-300 hover:text-amber-200 hover:bg-amber-500/15 ring-1 ring-amber-400/40"
                       : "text-white/40 hover:text-white/70 hover:bg-white/10"
                   )}
                 >
-                  {isMemberPreview ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  {isMemberPreview ? "Vue membre" : "Vue membre"}
+                  {isMemberPreview ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
                 </Button>
               )}
               <Link to="/profile">

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -19,7 +19,7 @@ const AvatarImage = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Image>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Image ref={ref} className={cn("aspect-square h-full w-full", className)} {...props} />
+  <AvatarPrimitive.Image ref={ref} className={cn("aspect-square h-full w-full object-cover", className)} {...props} />
 ));
 AvatarImage.displayName = AvatarPrimitive.Image.displayName;
 


### PR DESCRIPTION
Ajoute `object-cover` sur `AvatarImage` pour que les photos non carrées soient recadrées proprement dans le cercle au lieu d'être étirées.

https://claude.ai/code/session_01JHpgfwG9EpvvtzrcSFw3cJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHpgfwG9EpvvtzrcSFw3cJ)_