### PR TITLE
Trombi — agrandit la photo dans le dialog de contact

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,8 +25,7 @@
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__execute_sql",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__get_project",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__deploy_edge_function",
-      "mcp__Supabase__apply_migration",
-      "mcp__Supabase__execute_sql"
+      "mcp__Supabase__apply_migration"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,8 @@
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__execute_sql",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__get_project",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__deploy_edge_function",
-      "mcp__Supabase__apply_migration"
+      "mcp__Supabase__apply_migration",
+      "mcp__Supabase__execute_sql"
     ]
   }
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -103,18 +103,17 @@ const Header = () => {
               {canTogglePreview && (
                 <Button
                   variant="ghost"
-                  size="sm"
+                  size="icon"
                   onClick={toggleMemberPreview}
                   title={isMemberPreview ? "Repasser en vue encadrant" : "Simuler vue membre"}
                   className={cn(
-                    "gap-2 text-xs hidden lg:flex",
+                    "rounded-full hidden lg:flex",
                     isMemberPreview
                       ? "text-amber-300 hover:text-amber-200 hover:bg-amber-500/15 ring-1 ring-amber-400/40"
                       : "text-white/40 hover:text-white/70 hover:bg-white/10"
                   )}
                 >
-                  {isMemberPreview ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  {isMemberPreview ? "Vue membre" : "Vue membre"}
+                  {isMemberPreview ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
                 </Button>
               )}
               <Link to="/profile">

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -19,7 +19,7 @@ const AvatarImage = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Image>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Image ref={ref} className={cn("aspect-square h-full w-full", className)} {...props} />
+  <AvatarPrimitive.Image ref={ref} className={cn("aspect-square h-full w-full object-cover", className)} {...props} />
 ));
 AvatarImage.displayName = AvatarPrimitive.Image.displayName;
 

--- a/src/pages/Trombinoscope.tsx
+++ b/src/pages/Trombinoscope.tsx
@@ -60,18 +60,18 @@ const ContactDialog = ({ member, onClose }: ContactDialogProps) => {
     <Dialog open={!!member} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="sm:max-w-xs">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-3">
-            <Avatar className="h-10 w-10">
-              {member.avatar_url && <AvatarImage src={member.avatar_url} />}
-              <AvatarFallback className={`${getAvatarColor(member.first_name + member.last_name)} text-foreground font-semibold`}>
+          <div className="flex flex-col items-center gap-3 pt-2">
+            <Avatar className="h-28 w-28">
+              {member.avatar_url && <AvatarImage src={member.avatar_url} alt={`${member.first_name} ${member.last_name}`} />}
+              <AvatarFallback className={`${getAvatarColor(member.first_name + member.last_name)} text-foreground font-bold text-3xl`}>
                 {getInitials(member.first_name, member.last_name)}
               </AvatarFallback>
             </Avatar>
-            <div className="text-left leading-tight">
+            <DialogTitle className="text-center leading-tight">
               <p className="font-semibold">{formatFirstName(member.first_name)}</p>
               <p className="text-sm font-normal text-muted-foreground">{formatLastName(member.last_name)}</p>
-            </div>
-          </DialogTitle>
+            </DialogTitle>
+          </div>
         </DialogHeader>
 
         <div className="flex gap-3 pt-2 justify-center">


### PR DESCRIPTION
Photo passée de h-10 w-10 à h-28 w-28, centrée en haut du dialog, pour mieux voir la personne au clic.

https://claude.ai/code/session_01JHpgfwG9EpvvtzrcSFw3cJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHpgfwG9EpvvtzrcSFw3cJ)_