### PR TITLE
Redirection accueil à la désactivation vue membre sur page membre-only

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,8 +25,7 @@
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__execute_sql",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__get_project",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__deploy_edge_function",
-      "mcp__Supabase__apply_migration",
-      "mcp__Supabase__execute_sql"
+      "mcp__Supabase__apply_migration"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,8 @@
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__execute_sql",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__get_project",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__deploy_edge_function",
-      "mcp__Supabase__apply_migration"
+      "mcp__Supabase__apply_migration",
+      "mcp__Supabase__execute_sql"
     ]
   }
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { Waves, Calendar, User, Settings, LogOut, Image, FileText, MapIcon, CloudSun, Package, Users, Shield, Eye, EyeOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
@@ -11,6 +11,7 @@ import logoTeamOxygen from "@/assets/logo-team-oxygen.webp";
 
 const Header = () => {
   const location = useLocation();
+  const navigate = useNavigate();
   const { user, signOut } = useAuth();
   const { isAdmin, isOrganizer } = useUserRole();
   const { data: isEncadrantFromDirectory } = useIsCurrentUserEncadrant();
@@ -24,6 +25,14 @@ const Header = () => {
   const isEncadrant = isMemberPreview ? false : realIsEncadrant;
   const effectiveIsOrganizer = isMemberPreview ? false : isOrganizer;
   const canTogglePreview = realIsEncadrant || isAdmin;
+
+  // Pages accessibles uniquement en vue membre (cachées pour les encadrants)
+  const memberOnlyRoutes = ["/souvenirs", "/security"];
+  const handleTogglePreview = () => {
+    const isLeavingMemberView = isMemberPreview && memberOnlyRoutes.includes(location.pathname);
+    toggleMemberPreview();
+    if (isLeavingMemberView) navigate("/");
+  };
 
   const navItems = useMemo(() => {
     const items = [
@@ -104,7 +113,7 @@ const Header = () => {
                 <Button
                   variant="ghost"
                   size="icon"
-                  onClick={toggleMemberPreview}
+                  onClick={handleTogglePreview}
                   title={isMemberPreview ? "Repasser en vue encadrant" : "Simuler vue membre"}
                   className={cn(
                     "rounded-full hidden lg:flex",


### PR DESCRIPTION
Quand on désactive le mode "Vue membre" depuis une page réservée aux membres (/security, /souvenirs), on est automatiquement redirigé vers l'accueil.

https://claude.ai/code/session_01JHpgfwG9EpvvtzrcSFw3cJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHpgfwG9EpvvtzrcSFw3cJ)_