### PR TITLE
Affiche l'erreur exacte lors d'un échec de sauvegarde adhérent

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -26,7 +26,10 @@
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__get_project",
       "mcp__11e01d34-7492-4374-ac5a-799abc8513c3__deploy_edge_function",
       "mcp__Supabase__apply_migration",
-      "mcp__Supabase__execute_sql"
+      "mcp__Supabase__execute_sql",
+      "mcp__Vercel__list_teams",
+      "mcp__Vercel__list_projects",
+      "mcp__Vercel__list_deployments"
     ]
   }
 }

--- a/src/components/admin/ClubMembersDirectory.tsx
+++ b/src/components/admin/ClubMembersDirectory.tsx
@@ -311,7 +311,8 @@ const ClubMembersDirectory = () => {
       setIsFormOpen(false);
       resetForm();
     } catch (error) {
-      // Error handled in hook
+      const msg = error instanceof Error ? error.message : "Erreur lors de l'enregistrement";
+      toast.error(msg);
     }
   };
 

--- a/src/components/admin/MemberManager.tsx
+++ b/src/components/admin/MemberManager.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Users, Search, Crown, Trash2 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatFullName } from "@/lib/formatName";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
@@ -207,7 +208,7 @@ const MemberManager = () => {
                     </Avatar>
                     <div>
                       <p className="font-medium text-foreground">
-                        {profile.first_name} {profile.last_name}
+                        {formatFullName(profile.first_name, profile.last_name)}
                       </p>
                       <p className="text-xs text-muted-foreground">{profile.email}</p>
                       {profile.member_code && (
@@ -238,7 +239,7 @@ const MemberManager = () => {
                           <AlertDialogHeader>
                             <AlertDialogTitle>Supprimer ce compte ?</AlertDialogTitle>
                             <AlertDialogDescription>
-                              Le compte de <strong>{profile.first_name} {profile.last_name}</strong> ({profile.email}) sera définitivement supprimé. Cette action est irréversible.
+                              Le compte de <strong>{formatFullName(profile.first_name, profile.last_name)}</strong> ({profile.email}) sera définitivement supprimé. Cette action est irréversible.
                             </AlertDialogDescription>
                           </AlertDialogHeader>
                           <AlertDialogFooter>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { User, Session } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
+import { formatFirstName, formatLastName } from "@/lib/formatName";
 
 interface AuthContextType {
   user: User | null;
@@ -55,8 +56,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       options: {
         emailRedirectTo: redirectUrl,
         data: {
-          first_name: firstName,
-          last_name: lastName,
+          first_name: formatFirstName(firstName),
+          last_name: formatLastName(lastName),
         },
       },
     });

--- a/src/hooks/useClubMembersDirectory.ts
+++ b/src/hooks/useClubMembersDirectory.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import { formatFirstName, formatLastName } from "@/lib/formatName";
 
 // ClubMember now only contains identity fields (seasonal fields are in membership_yearly_status)
 export interface ClubMember {
@@ -75,8 +76,8 @@ export const useClubMembersDirectory = () => {
       const { data, error } = await supabase
         .from("club_members_directory")
         .insert({
-          first_name: member.first_name,
-          last_name: member.last_name,
+          first_name: formatFirstName(member.first_name),
+          last_name: formatLastName(member.last_name),
           email: member.email,
           phone: member.phone,
           birth_date: member.birth_date,
@@ -110,6 +111,8 @@ export const useClubMembersDirectory = () => {
   // Update member
   const updateMember = useMutation({
     mutationFn: async ({ id, ...updates }: Partial<ClubMember> & { id: string }) => {
+      if (updates.first_name) updates.first_name = formatFirstName(updates.first_name);
+      if (updates.last_name) updates.last_name = formatLastName(updates.last_name);
       const { data, error } = await supabase
         .from("club_members_directory")
         .update(updates)
@@ -163,8 +166,8 @@ export const useClubMembersDirectory = () => {
         const { data, error } = await supabase
           .from("club_members_directory")
           .update({
-            first_name: member.first_name,
-            last_name: member.last_name,
+            first_name: formatFirstName(member.first_name),
+            last_name: formatLastName(member.last_name),
             phone: member.phone,
             birth_date: member.birth_date,
             address: member.address,
@@ -185,8 +188,8 @@ export const useClubMembersDirectory = () => {
         const { data, error } = await supabase
           .from("club_members_directory")
           .insert({
-            first_name: member.first_name,
-            last_name: member.last_name,
+            first_name: formatFirstName(member.first_name),
+            last_name: formatLastName(member.last_name),
             email: member.email.toLowerCase(),
             phone: member.phone,
             birth_date: member.birth_date,

--- a/src/hooks/useMembershipYearlyStatus.ts
+++ b/src/hooks/useMembershipYearlyStatus.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { toast } from "sonner";
 
 export interface MembershipYearlyStatus {
   id: string;
@@ -172,6 +173,9 @@ export const useMembershipYearlyStatus = (seasonYear: number) => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["membership-yearly-status", seasonYear] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Erreur lors de la mise à jour des données saisonnières");
     },
   });
 

--- a/src/hooks/useProfileDirectory.ts
+++ b/src/hooks/useProfileDirectory.ts
@@ -21,6 +21,8 @@ export interface ProfileDirectoryData {
 }
 
 export interface ProfileDirectoryUpdate {
+  first_name?: string;
+  last_name?: string;
   phone?: string | null;
   address?: string | null;
   emergency_contact_name?: string | null;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -18,6 +18,7 @@ import { useViewMode } from "@/contexts/ViewModeContext";
 import { useProfileDirectory } from "@/hooks/useProfileDirectory";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import { formatFirstName, formatLastName } from "@/lib/formatName";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { QRCodeSVG } from "qrcode.react";
@@ -115,8 +116,8 @@ const Profile = () => {
       const { error: profileError } = await supabase
         .from("profiles")
         .update({
-          first_name: data.first_name,
-          last_name: data.last_name,
+          first_name: formatFirstName(data.first_name),
+          last_name: formatLastName(data.last_name),
           phone: normalizedPhone,
         })
         .eq("id", user.id);

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -127,6 +127,8 @@ const Profile = () => {
       // Update directory profile if exists
       if (directoryProfile) {
         await updateDirectoryProfile.mutateAsync({
+          first_name: formatFirstName(data.first_name),
+          last_name: formatLastName(data.last_name),
           phone: data.phone || null,
           address: data.address || null,
           emergency_contact_name: data.emergency_contact_name || null,


### PR DESCRIPTION
Le catch dans handleSubmit était silencieux — on ne savait pas pourquoi le dialog ne se fermait pas. Maintenant l'erreur exacte s'affiche en toast.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVFdVN5nJ883NpJFLoSEYS)_