### PR TITLE
fix: auto-inscription organisateur + améliorations archives et souvenirs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -29,7 +29,8 @@
       "mcp__Supabase__execute_sql",
       "mcp__Vercel__list_teams",
       "mcp__Vercel__list_projects",
-      "mcp__Vercel__list_deployments"
+      "mcp__Vercel__list_deployments",
+      "mcp__Supabase__get_logs"
     ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@tanstack/react-query": "^5.83.0",
         "@types/leaflet": "^1.9.21",
         "@types/uuid": "^10.0.0",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -3474,6 +3475,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.25.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
@@ -6390,6 +6400,12 @@
       "bin": {
         "uuid": "dist-node/bin/uuid"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/vaul": {
       "version": "0.9.9",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@tanstack/react-query": "^5.83.0",
     "@types/leaflet": "^1.9.21",
     "@types/uuid": "^10.0.0",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/components/outings/EditHistoricalOutingDialog.tsx
+++ b/src/components/outings/EditHistoricalOutingDialog.tsx
@@ -1,0 +1,439 @@
+import { useState, useMemo, useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { CalendarIcon, Search, Pencil, Loader2, Check, Users } from "lucide-react";
+import { format } from "date-fns";
+import { fr } from "date-fns/locale";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { supabase } from "@/integrations/supabase/client";
+import { useLocations } from "@/hooks/useLocations";
+import { useMembersForEncadrant } from "@/hooks/useMembersForEncadrant";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+
+const schema = z.object({
+  date: z.date({ required_error: "La date est requise" }),
+  location_id: z.string().optional(),
+  location: z.string().min(1, "Le lieu est requis"),
+  outing_type: z.enum(["Fosse", "Mer", "Piscine", "Étang", "Dépollution"]),
+  organizer_id: z.string().min(1, "L'organisateur est requis"),
+});
+
+type FormData = z.infer<typeof schema>;
+
+interface Props {
+  outing: {
+    id: string;
+    title: string;
+    date_time: string;
+    location: string;
+    location_id?: string | null;
+    outing_type: string;
+    organizer_member_id?: string | null;
+    historicalMembers: { id: string; first_name: string; last_name: string }[];
+  };
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const EditHistoricalOutingDialog = ({ outing, open, onOpenChange }: Props) => {
+  const queryClient = useQueryClient();
+  const { data: locations } = useLocations();
+  const { data: members, isLoading: membersLoading } = useMembersForEncadrant();
+  const [isDateOpen, setIsDateOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedMemberIds, setSelectedMemberIds] = useState<Set<string>>(new Set());
+  const [coInstructorMemberId, setCoInstructorMemberId] = useState("");
+
+  const { data: encadrants } = useQuery({
+    queryKey: ["encadrants-for-selection"],
+    queryFn: async () => {
+      const currentSeasonYear = new Date().getMonth() >= 8
+        ? new Date().getFullYear() + 1
+        : new Date().getFullYear();
+      const { data: statuses } = await supabase
+        .from("membership_yearly_status")
+        .select("member_id")
+        .eq("season_year", currentSeasonYear)
+        .eq("is_encadrant", true);
+      const ids = statuses?.map((s) => s.member_id) ?? [];
+      if (ids.length === 0) return [];
+      const { data } = await supabase
+        .from("club_members_directory")
+        .select("id, first_name, last_name, email")
+        .in("id", ids)
+        .order("last_name");
+      return data ?? [];
+    },
+  });
+
+  const { data: profiles } = useQuery({
+    queryKey: ["profiles-for-organizer-mapping"],
+    queryFn: async () => {
+      const { data } = await supabase.from("profiles").select("id, email");
+      return data ?? [];
+    },
+  });
+
+  const emailToProfileIdMap = useMemo(() => {
+    if (!profiles) return new Map<string, string>();
+    return new Map(profiles.map((p) => [p.email.toLowerCase(), p.id]));
+  }, [profiles]);
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      location: "",
+      location_id: "",
+      outing_type: "Mer",
+      organizer_id: "",
+    },
+  });
+
+  // Initialize form with outing data when dialog opens
+  useEffect(() => {
+    if (!open) return;
+    form.reset({
+      date: new Date(outing.date_time),
+      location: outing.location,
+      location_id: outing.location_id ?? "",
+      outing_type: outing.outing_type as FormData["outing_type"],
+      organizer_id: outing.organizer_member_id ?? "",
+    });
+    setSelectedMemberIds(new Set(outing.historicalMembers.map((m) => m.id)));
+    setCoInstructorMemberId("");
+    setSearchQuery("");
+  }, [open, outing]);
+
+  const filteredMembers = useMemo(() => {
+    if (!members) return [];
+    if (!searchQuery.trim()) return members;
+    const q = searchQuery.toLowerCase();
+    return members.filter(
+      (m) => m.first_name.toLowerCase().includes(q) || m.last_name.toLowerCase().includes(q)
+    );
+  }, [members, searchQuery]);
+
+  const toggleMember = (id: string) => {
+    setSelectedMemberIds((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const updateMutation = useMutation({
+    mutationFn: async (data: FormData) => {
+      const startDateTime = new Date(data.date);
+      startDateTime.setHours(10, 0, 0, 0);
+
+      const title = `${data.outing_type} - ${data.location}`;
+
+      // Find organizer profile id
+      const selectedEncadrant = encadrants?.find((e) => e.id === data.organizer_id);
+      let organizerProfileId: string | null = null;
+      if (selectedEncadrant?.email) {
+        organizerProfileId = emailToProfileIdMap.get(selectedEncadrant.email.toLowerCase()) ?? null;
+      }
+
+      // Find co-instructor profile id
+      let coInstructorProfileId: string | null = null;
+      if (coInstructorMemberId) {
+        const coEnc = encadrants?.find((e) => e.id === coInstructorMemberId);
+        if (coEnc?.email) {
+          coInstructorProfileId = emailToProfileIdMap.get(coEnc.email.toLowerCase()) ?? null;
+        }
+      }
+
+      // 1. Update outing
+      const { error: outingError } = await supabase
+        .from("outings")
+        .update({
+          title,
+          date_time: startDateTime.toISOString(),
+          location: data.location,
+          location_id: data.location_id || null,
+          outing_type: data.outing_type,
+          organizer_id: organizerProfileId,
+          organizer_member_id: data.organizer_id,
+          max_participants: Math.max(selectedMemberIds.size, 10),
+        })
+        .eq("id", outing.id);
+      if (outingError) throw outingError;
+
+      // 2. Replace all historical participants
+      await supabase.from("historical_outing_participants").delete().eq("outing_id", outing.id);
+
+      const allIds = new Set(selectedMemberIds);
+      allIds.add(data.organizer_id);
+      if (coInstructorMemberId) allIds.add(coInstructorMemberId);
+
+      if (allIds.size > 0) {
+        const { error: participantsError } = await supabase
+          .from("historical_outing_participants")
+          .insert(Array.from(allIds).map((memberId) => ({ outing_id: outing.id, member_id: memberId })));
+        if (participantsError) throw participantsError;
+      }
+
+      // 3. Update co-instructor in outing_co_instructors
+      await supabase.from("outing_co_instructors").delete().eq("outing_id", outing.id);
+      if (coInstructorProfileId) {
+        await supabase
+          .from("outing_co_instructors")
+          .insert({ outing_id: outing.id, user_id: coInstructorProfileId });
+      }
+    },
+    onSuccess: () => {
+      toast.success("Sortie historique modifiée");
+      queryClient.invalidateQueries({ queryKey: ["past-outings-archives"] });
+      onOpenChange(false);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Erreur lors de la modification");
+    },
+  });
+
+  const selectedLocationId = form.watch("location_id");
+  const organizerId = form.watch("organizer_id");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl h-[95dvh] sm:h-auto sm:max-h-[90vh] flex flex-col overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Pencil className="h-5 w-5 text-primary" />
+            Modifier la sortie historique
+          </DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit((data) => updateMutation.mutate(data))}
+            className="flex flex-col flex-1 gap-4 overflow-y-auto pb-4"
+          >
+            <div className="grid gap-4 sm:grid-cols-3">
+              <FormField
+                control={form.control}
+                name="date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Date</FormLabel>
+                    <Popover open={isDateOpen} onOpenChange={setIsDateOpen}>
+                      <PopoverTrigger asChild>
+                        <FormControl>
+                          <Button
+                            variant="outline"
+                            className={cn("w-full justify-start text-left font-normal", !field.value && "text-muted-foreground")}
+                          >
+                            <CalendarIcon className="mr-2 h-4 w-4" />
+                            {field.value ? format(field.value, "PPP", { locale: fr }) : "Date"}
+                          </Button>
+                        </FormControl>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-auto p-0" align="start">
+                        <Calendar
+                          mode="single"
+                          selected={field.value}
+                          onSelect={(date) => { field.onChange(date); setIsDateOpen(false); }}
+                          disabled={(date) => { const today = new Date(); today.setHours(23,59,59,999); return date > today; }}
+                          initialFocus
+                          className="pointer-events-auto"
+                        />
+                      </PopoverContent>
+                    </Popover>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="location_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Lieu</FormLabel>
+                    <Select
+                      onValueChange={(val) => {
+                        field.onChange(val);
+                        const loc = locations?.find((l) => l.id === val);
+                        if (loc) form.setValue("location", loc.name);
+                      }}
+                      value={field.value || ""}
+                    >
+                      <FormControl>
+                        <SelectTrigger><SelectValue placeholder="Sélectionner" /></SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {locations?.map((l) => (
+                          <SelectItem key={l.id} value={l.id}>{l.name}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="outing_type"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Type</FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger><SelectValue /></SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {["Mer","Piscine","Dépollution","Fosse","Étang"].map((t) => (
+                          <SelectItem key={t} value={t}>{t}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {!selectedLocationId && (
+              <FormField
+                control={form.control}
+                name="location"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Ou saisir un lieu</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Marseille, Calanque de Sormiou" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name="organizer_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Organisateur</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger><SelectValue placeholder="Sélectionner l'organisateur" /></SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {encadrants?.map((e) => (
+                        <SelectItem key={e.id} value={e.id}>{e.first_name} {e.last_name}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="space-y-2">
+              <FormLabel>Co-encadrant (optionnel)</FormLabel>
+              <Select
+                value={coInstructorMemberId}
+                onValueChange={(val) => setCoInstructorMemberId(val === "none" ? "" : val)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Aucun co-encadrant" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Aucun</SelectItem>
+                  {encadrants?.filter((e) => e.id !== organizerId).map((e) => (
+                    <SelectItem key={e.id} value={e.id}>{e.first_name} {e.last_name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex flex-col border rounded-lg overflow-hidden min-h-[200px] max-h-[35vh]">
+              <div className="p-3 border-b bg-muted/30">
+                <div className="flex items-center gap-2">
+                  <div className="relative flex-1">
+                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                    <Input
+                      placeholder="Chercher un nom..."
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      className="pl-9"
+                    />
+                  </div>
+                  <Button type="button" variant="outline" size="sm"
+                    onClick={() => setSelectedMemberIds((p) => { const n = new Set(p); filteredMembers.forEach((m) => n.add(m.id)); return n; })}>
+                    Tout
+                  </Button>
+                  <Button type="button" variant="ghost" size="sm" onClick={() => setSelectedMemberIds(new Set())}>
+                    Aucun
+                  </Button>
+                </div>
+              </div>
+
+              {membersLoading ? (
+                <div className="flex-1 flex items-center justify-center">
+                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                </div>
+              ) : (
+                <ScrollArea className="flex-1">
+                  <div className="divide-y">
+                    {filteredMembers.map((member) => (
+                      <label
+                        key={member.id}
+                        className={cn(
+                          "flex items-center gap-3 p-3 cursor-pointer hover:bg-muted/50 transition-colors",
+                          selectedMemberIds.has(member.id) && "bg-primary/5"
+                        )}
+                      >
+                        <Checkbox
+                          checked={selectedMemberIds.has(member.id)}
+                          onCheckedChange={() => toggleMember(member.id)}
+                        />
+                        <span className="flex-1">{member.last_name} {member.first_name}</span>
+                        {selectedMemberIds.has(member.id) && <Check className="h-4 w-4 text-primary" />}
+                      </label>
+                    ))}
+                  </div>
+                </ScrollArea>
+              )}
+
+              <div className="p-3 border-t bg-muted/30 flex items-center gap-2 text-sm text-muted-foreground">
+                <Users className="h-4 w-4" />
+                <span>
+                  <strong className="text-foreground">{selectedMemberIds.size}</strong> participant
+                  {selectedMemberIds.size > 1 ? "s" : ""} sélectionné{selectedMemberIds.size > 1 ? "s" : ""}
+                </span>
+              </div>
+            </div>
+
+            <Button
+              type="submit"
+              variant="ocean"
+              className="w-full"
+              disabled={updateMutation.isPending}
+            >
+              {updateMutation.isPending ? (
+                <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Enregistrement...</>
+              ) : (
+                "Enregistrer les modifications"
+              )}
+            </Button>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default EditHistoricalOutingDialog;

--- a/src/components/outings/HistoricalOutingForm.tsx
+++ b/src/components/outings/HistoricalOutingForm.tsx
@@ -46,6 +46,7 @@ const HistoricalOutingForm = ({ open, onOpenChange }: HistoricalOutingFormProps)
   const [isDateOpen, setIsDateOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedMemberIds, setSelectedMemberIds] = useState<Set<string>>(new Set());
+  const [coInstructorMemberId, setCoInstructorMemberId] = useState<string>("");
 
   // Fetch encadrants from membership_yearly_status joined with club_members_directory
   const { data: encadrants } = useQuery({
@@ -197,6 +198,14 @@ const HistoricalOutingForm = ({ open, onOpenChange }: HistoricalOutingFormProps)
     // Generate a title based on type and location
     const title = `${data.outing_type} - ${data.location}`;
 
+    let coInstructorProfileId: string | null = null;
+    if (coInstructorMemberId) {
+      const coEncadrant = encadrants?.find((e) => e.id === coInstructorMemberId);
+      if (coEncadrant?.email) {
+        coInstructorProfileId = emailToProfileIdMap.get(coEncadrant.email.toLowerCase()) ?? null;
+      }
+    }
+
     await createHistoricalOuting.mutateAsync({
       title,
       date_time: startDateTime.toISOString(),
@@ -204,7 +213,9 @@ const HistoricalOutingForm = ({ open, onOpenChange }: HistoricalOutingFormProps)
       location_id: data.location_id || undefined,
       outing_type: data.outing_type,
       organizer_id: organizerProfileId,
-      organizer_member_id: data.organizer_id, // club_members_directory ID
+      organizer_member_id: data.organizer_id,
+      co_instructor_member_id: coInstructorMemberId || null,
+      co_instructor_profile_id: coInstructorProfileId,
       participant_member_ids: Array.from(selectedMemberIds),
     });
 
@@ -212,6 +223,7 @@ const HistoricalOutingForm = ({ open, onOpenChange }: HistoricalOutingFormProps)
     form.reset();
     setSelectedMemberIds(new Set());
     setSearchQuery("");
+    setCoInstructorMemberId("");
     onOpenChange(false);
   };
 
@@ -371,6 +383,29 @@ const HistoricalOutingForm = ({ open, onOpenChange }: HistoricalOutingFormProps)
                 </FormItem>
               )}
             />
+
+            {/* Co-instructor */}
+            <div className="space-y-2">
+              <FormLabel>Co-encadrant (optionnel)</FormLabel>
+              <Select
+                value={coInstructorMemberId}
+                onValueChange={(val) => setCoInstructorMemberId(val === "none" ? "" : val)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Aucun co-encadrant" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Aucun</SelectItem>
+                  {encadrants
+                    ?.filter((e) => e.id !== form.watch("organizer_id"))
+                    .map((e) => (
+                      <SelectItem key={e.id} value={e.id}>
+                        {e.first_name} {e.last_name}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            </div>
 
             {/* Members selection section */}
             <div className="flex flex-col border rounded-lg overflow-hidden min-h-[200px] max-h-[40vh]">

--- a/src/hooks/useCreateHistoricalOuting.ts
+++ b/src/hooks/useCreateHistoricalOuting.ts
@@ -12,6 +12,8 @@ interface HistoricalOutingData {
   outing_type: OutingType;
   organizer_id: string | null; // Profile ID (for outings table) - null if encadrant has no app account
   organizer_member_id: string; // club_members_directory ID (for historical participants)
+  co_instructor_member_id?: string | null; // club_members_directory ID
+  co_instructor_profile_id?: string | null; // profiles ID if they have an app account
   participant_member_ids: string[]; // IDs from club_members_directory
 }
 
@@ -50,12 +52,23 @@ export const useCreateHistoricalOuting = () => {
       if (outingError) throw outingError;
       if (!newOuting) throw new Error("Failed to create outing");
 
-      // 2. Create historical_outing_participants entries
+      // 2. Insert co-instructor into outing_co_instructors if they have a profile
+      if (data.co_instructor_profile_id) {
+        const { error: coError } = await supabase
+          .from("outing_co_instructors")
+          .insert({ outing_id: newOuting.id, user_id: data.co_instructor_profile_id });
+        if (coError) console.error("Error adding co-instructor:", coError);
+      }
+
+      // 3. Create historical_outing_participants entries
       // These are linked to club_members_directory, NOT to profiles
-      // Always include the organizer as a participant
+      // Always include the organizer and co-instructor as participants
       const allParticipantIds = new Set(data.participant_member_ids);
       if (data.organizer_member_id) {
         allParticipantIds.add(data.organizer_member_id);
+      }
+      if (data.co_instructor_member_id) {
+        allParticipantIds.add(data.co_instructor_member_id);
       }
       
       if (allParticipantIds.size > 0) {

--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -487,36 +487,33 @@ export const useCreateOuting = () => {
       dive_mode?: "boat" | "shore";
       boat_id?: string;
     }) => {
-      // Extract carpool options before creating the outing
-      const { carpool_option, carpool_seats, ...outingData } = outing;
-      
-      // Create the outing
-      const { data: newOuting, error } = await supabase
-        .from("outings")
-        .insert(outingData)
-        .select("id")
-        .single();
-      
+      if (!outing.organizer_id) throw new Error("Utilisateur non connecté");
+
+      const { data: outingId, error } = await supabase.rpc(
+        "create_outing_with_organizer",
+        {
+          p_title: outing.title,
+          p_description: outing.description ?? null,
+          p_date_time: outing.date_time,
+          p_end_date: outing.end_date ?? null,
+          p_water_entry_time: outing.water_entry_time ?? null,
+          p_water_exit_time: outing.water_exit_time ?? null,
+          p_location: outing.location,
+          p_location_id: outing.location_id ?? null,
+          p_outing_type: outing.outing_type,
+          p_max_participants: outing.max_participants,
+          p_organizer_id: outing.organizer_id,
+          p_is_staff_only: outing.is_staff_only ?? false,
+          p_carpool_option: outing.carpool_option ?? "none",
+          p_carpool_seats: outing.carpool_seats ?? 1,
+          p_dive_mode: outing.dive_mode ?? null,
+          p_boat_id: outing.boat_id ?? null,
+        }
+      );
+
       if (error) throw error;
 
-      // Auto-register the organizer with their carpool preference
-      if (outing.organizer_id && newOuting) {
-        const { error: reservationError } = await supabase
-          .from("reservations")
-          .insert({
-            outing_id: newOuting.id,
-            user_id: outing.organizer_id,
-            status: "confirmé",
-            carpool_option: carpool_option || "none",
-            carpool_seats: carpool_option === "driver" ? (carpool_seats || 1) : 0,
-          });
-
-        if (reservationError) {
-          console.error("Error auto-registering organizer:", reservationError);
-        }
-      }
-
-      return newOuting;
+      return { id: outingId as string };
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["outings"] });

--- a/src/pages/Archives.tsx
+++ b/src/pages/Archives.tsx
@@ -14,6 +14,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import imageCompression from "browser-image-compression";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUserRole } from "@/hooks/useUserRole";
@@ -176,12 +177,17 @@ const Archives = () => {
     
     try {
       for (const file of Array.from(files).slice(0, 4)) {
+        const compressed = await imageCompression(file, {
+          maxSizeMB: 0.5,
+          maxWidthOrHeight: 1200,
+          useWebWorker: true,
+        });
         const fileExt = file.name.split(".").pop();
         const fileName = `${outingId}/${Date.now()}-${Math.random().toString(36).substring(7)}.${fileExt}`;
-        
+
         const { error: uploadError } = await supabase.storage
           .from("outings_gallery")
-          .upload(fileName, file);
+          .upload(fileName, compressed);
           
         if (uploadError) throw uploadError;
         

--- a/src/pages/Archives.tsx
+++ b/src/pages/Archives.tsx
@@ -714,21 +714,30 @@ const Archives = () => {
                       </div>
                     </div>
 
+                    {/* Photo thumbnails */}
+                    {outing.photos && outing.photos.length > 0 && (
+                      <div className="flex gap-2 mb-3">
+                        {outing.photos.map((photo: string, idx: number) => (
+                          <div key={idx} className="h-16 w-24 rounded-md overflow-hidden flex-shrink-0 bg-muted">
+                            <img
+                              src={photo}
+                              alt={`Photo ${idx + 1}`}
+                              className="h-full w-full object-cover"
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    )}
+
                     {/* Quick stats */}
                     <div className="flex flex-wrap gap-4 text-sm">
                       <span className="flex items-center gap-2 text-muted-foreground">
                         <Users className="h-4 w-4" />
-                        {outing.isHistorical 
+                        {outing.isHistorical
                           ? `${outing.totalParticipantCount} présents`
                           : `${outing.presentParticipants.length}/${outing.confirmedParticipants.length} présents`
                         }
                       </span>
-                      {outing.photos && outing.photos.length > 0 && (
-                        <span className="flex items-center gap-2 text-muted-foreground">
-                          <Image className="h-4 w-4" />
-                          {outing.photos.length} photo(s)
-                        </span>
-                      )}
                       {outing.session_report && (
                         <Badge variant="outline" className="text-xs">
                           <FileText className="h-3 w-3 mr-1" />

--- a/src/pages/Archives.tsx
+++ b/src/pages/Archives.tsx
@@ -3,7 +3,7 @@ import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
-import { Calendar, MapPin, Loader2, Image, Users, Search, FileText, Download, Upload, Edit, Save, X } from "lucide-react";
+import { Calendar, MapPin, Loader2, Image, Users, Search, FileText, Download, Upload, Edit, Save, X, Pencil } from "lucide-react";
 import Layout from "@/components/layout/Layout";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -18,6 +18,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUserRole } from "@/hooks/useUserRole";
 import { toast } from "sonner";
+import EditHistoricalOutingDialog from "@/components/outings/EditHistoricalOutingDialog";
 
 const Archives = () => {
   const navigate = useNavigate();
@@ -29,6 +30,7 @@ const Archives = () => {
   const [uploadingOutingId, setUploadingOutingId] = useState<string | null>(null);
   const [editingReportId, setEditingReportId] = useState<string | null>(null);
   const [reportDraft, setReportDraft] = useState<string>("");
+  const [editingHistoricalOuting, setEditingHistoricalOuting] = useState<any | null>(null);
   const [selectedEncadrant, setSelectedEncadrant] = useState<string>("all");
 
   const currentYear = new Date().getFullYear();
@@ -472,6 +474,16 @@ const Archives = () => {
                         </div>
                       </div>
                       <div className="flex gap-2">
+                        {outing.isHistorical && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setEditingHistoricalOuting(outing)}
+                          >
+                            <Pencil className="h-4 w-4 mr-2" />
+                            Modifier
+                          </Button>
+                        )}
                         <Dialog>
                           <DialogTrigger asChild>
                             <Button variant="ocean" size="sm">
@@ -731,6 +743,14 @@ const Archives = () => {
           )}
         </div>
       </section>
+
+      {editingHistoricalOuting && (
+        <EditHistoricalOutingDialog
+          outing={editingHistoricalOuting}
+          open={!!editingHistoricalOuting}
+          onOpenChange={(open) => { if (!open) setEditingHistoricalOuting(null); }}
+        />
+      )}
     </Layout>
   );
 };

--- a/src/pages/Souvenirs.tsx
+++ b/src/pages/Souvenirs.tsx
@@ -21,57 +21,86 @@ const Souvenirs = () => {
     queryKey: ["past-outings-souvenirs", user?.id],
     queryFn: async () => {
       if (!user) return [];
-      
+
       const now = new Date().toISOString();
-      
-      // First get the user's past reservations where they were present
-      const { data: myReservations, error: resError } = await supabase
+
+      // 1. Sorties régulières : reservations is_present = true
+      const { data: myReservations } = await supabase
         .from("reservations")
         .select(`
           outing_id,
           outing:outings(
-            id,
-            title,
-            outing_type,
-            date_time,
-            location,
-            photos,
-            is_deleted,
+            id, title, outing_type, date_time, location, photos, is_deleted, is_archived,
             location_details:locations(name)
           )
         `)
         .eq("user_id", user.id)
         .eq("status", "confirmé")
         .eq("is_present", true);
-      
-      if (resError) throw resError;
-      
-      // Filter to past outings only
-      const pastOutingsData = myReservations
-        ?.filter(r => 
-          r.outing && 
-          !r.outing.is_deleted && 
-          new Date(r.outing.date_time) < new Date(now)
-        )
-        .map(r => r.outing) ?? [];
-      
-      // Fetch participants for each outing using SECURITY DEFINER function
+
+      const regularOutings = (myReservations ?? [])
+        .filter(r => r.outing && !r.outing.is_deleted && !r.outing.is_archived && new Date(r.outing.date_time) < new Date(now))
+        .map(r => ({ ...r.outing, isHistorical: false }));
+
+      // 2. Sorties historiques : historical_outing_participants via email -> club_members_directory
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("email")
+        .eq("id", user.id)
+        .single();
+
+      let historicalOutings: any[] = [];
+      if (profile?.email) {
+        const { data: member } = await supabase
+          .from("club_members_directory")
+          .select("id")
+          .ilike("email", profile.email)
+          .maybeSingle();
+
+        if (member?.id) {
+          const { data: histParts } = await supabase
+            .from("historical_outing_participants")
+            .select(`
+              outing:outings(
+                id, title, outing_type, date_time, location, photos, is_deleted, is_archived,
+                location_details:locations(name)
+              )
+            `)
+            .eq("member_id", member.id);
+
+          historicalOutings = (histParts ?? [])
+            .filter(h => h.outing && !h.outing.is_deleted && h.outing.is_archived)
+            .map(h => ({ ...h.outing, isHistorical: true }));
+        }
+      }
+
+      // 3. Merge, dédupliquer, enrichir avec participants
+      const allOutings = [...regularOutings, ...historicalOutings]
+        .filter((o, i, arr) => arr.findIndex(x => x.id === o.id) === i);
+
       const outingsWithParticipants = await Promise.all(
-        pastOutingsData.map(async (outing: any) => {
-          const { data: participants } = await supabase
-            .rpc('get_outing_participants', { outing_uuid: outing.id });
-          
-          return {
-            ...outing,
-            presentParticipants: (participants ?? []).filter(
-              (p: any) => p.status !== "en_attente"
-            ),
-          };
+        allOutings.map(async (outing: any) => {
+          if (outing.isHistorical) {
+            const { data: histMembers } = await supabase
+              .from("historical_outing_participants")
+              .select("member:club_members_directory(id, first_name, last_name)")
+              .eq("outing_id", outing.id);
+            return {
+              ...outing,
+              presentParticipants: (histMembers ?? []).map((h: any) => h.member).filter(Boolean),
+            };
+          } else {
+            const { data: participants } = await supabase
+              .rpc("get_outing_participants", { outing_uuid: outing.id });
+            return {
+              ...outing,
+              presentParticipants: (participants ?? []).filter((p: any) => p.status !== "en_attente"),
+            };
+          }
         })
       );
-      
-      // Sort by date descending
-      return outingsWithParticipants.sort((a, b) => 
+
+      return outingsWithParticipants.sort((a, b) =>
         new Date(b.date_time).getTime() - new Date(a.date_time).getTime()
       );
     },

--- a/supabase/migrations/20260605120000_create_outing_with_organizer.sql
+++ b/supabase/migrations/20260605120000_create_outing_with_organizer.sql
@@ -1,0 +1,65 @@
+-- Fonction atomique : crée une sortie ET inscrit l'organisateur en une seule transaction.
+-- SECURITY DEFINER pour bypasser les politiques RLS sur reservations.
+CREATE OR REPLACE FUNCTION public.create_outing_with_organizer(
+  p_title text,
+  p_description text,
+  p_date_time timestamptz,
+  p_end_date timestamptz,
+  p_water_entry_time text,
+  p_water_exit_time text,
+  p_location text,
+  p_location_id uuid,
+  p_outing_type text,
+  p_max_participants int,
+  p_organizer_id uuid,
+  p_is_staff_only boolean,
+  p_carpool_option text,
+  p_carpool_seats int,
+  p_dive_mode text,
+  p_boat_id uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_outing_id uuid;
+BEGIN
+  -- Vérification : seul l'utilisateur connecté peut créer pour lui-même
+  IF auth.uid() IS NULL OR auth.uid() != p_organizer_id THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  INSERT INTO public.outings (
+    title, description, date_time, end_date,
+    water_entry_time, water_exit_time,
+    location, location_id,
+    outing_type, max_participants,
+    organizer_id, is_staff_only,
+    dive_mode, boat_id
+  ) VALUES (
+    p_title, p_description, p_date_time, p_end_date,
+    p_water_entry_time, p_water_exit_time,
+    p_location, p_location_id,
+    p_outing_type::public.outing_type, p_max_participants,
+    p_organizer_id, p_is_staff_only,
+    p_dive_mode, p_boat_id
+  )
+  RETURNING id INTO v_outing_id;
+
+  -- Inscription automatique de l'organisateur
+  INSERT INTO public.reservations (
+    outing_id, user_id, status,
+    carpool_option, carpool_seats
+  ) VALUES (
+    v_outing_id,
+    p_organizer_id,
+    'confirmé',
+    COALESCE(p_carpool_option, 'none')::public.carpool_option,
+    CASE WHEN p_carpool_option = 'driver' THEN COALESCE(p_carpool_seats, 1) ELSE 0 END
+  );
+
+  RETURN v_outing_id;
+END;
+$$;


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- **fix: auto-inscription organisateur** — remplace le double insert client par une fonction SQL `SECURITY DEFINER` (`create_outing_with_organizer`) qui crée l'outing et la réservation de l'organisateur de façon atomique. Corrige les échecs silencieux liés aux politiques RLS.

- **fix: inscription manuelle des organisateurs existants** — les organisateurs des sorties créées avant ce fix ont été inscrits directement en base.

- **feat: co-encadrant dans la saisie historique** — nouveau champ "Co-encadrant (optionnel)" dans le formulaire de saisie de sortie passée.

- **feat: modification des sorties historiques** — bouton "Modifier" sur chaque sortie historique dans les Archives, permettant de corriger date, lieu, type, organisateur, co-encadrant et participants.

- **feat: vignettes photos dans les Archives** — les photos s'affichent directement sur les cartes au lieu d'un simple compteur.

- **feat: compression photos automatique** — les photos sont compressées à 500 Ko / 1200px avant l'upload pour économiser le stockage Supabase gratuit (1 Go).

- **fix: sorties historiques visibles dans Souvenirs** — les membres participant à des sorties historiques les voient maintenant dans leur page Souvenirs (jointure via email → club_members_directory).

## Migration SQL à appliquer

La fonction `create_outing_with_organizer` a déjà été déployée manuellement en base de production.

## Test plan

- [ ] Créer une nouvelle sortie → vérifier que l'organisateur est automatiquement inscrit
- [ ] Saisir une sortie historique avec co-encadrant → vérifier l'affichage dans Archives
- [ ] Modifier une sortie historique → vérifier les changements
- [ ] Vérifier les vignettes photos dans Archives
- [ ] Uploader une photo → vérifier la compression (< 500 Ko)
- [ ] En vue membre, vérifier que les sorties historiques apparaissent dans Souvenirs

https://claude.ai/code/session_01RpzUVW67nJKJcVq2Zsw58C
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpzUVW67nJKJcVq2Zsw58C)_