### PR TITLE
feat: co-encadrant dans les archives + docs triggers DWH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,11 +150,23 @@ ALTER TABLE <table> DISABLE TRIGGER <trigger>;
 ALTER TABLE <table> ENABLE TRIGGER <trigger>;
 ```
 
-### Triggers DWH connus par table
+### Triggers DWH — liste complète
 
-| Table | Trigger DWH | Table DWH cible |
-|-------|-------------|-----------------|
-| `reservations` | `trg_dwh_reservations` | `fait_participation` |
-| `locations` | `trg_dwh_locations` | `dim_site` |
-| `outing_co_instructors` | `trg_dwh_co_instructeurs` | `fait_co_instructeur` |
-| `membership_yearly_status` | `trg_dwh_membership` | `fait_adhesion` |
+| Table source | Trigger(s) DWH |
+|--------------|----------------|
+| `carpool_passengers` | `trg_dwh_carpool_passengers` |
+| `carpools` | `trg_dwh_carpools` |
+| `club_members_directory` | `trg_dwh_cmd` |
+| `equipment_history` | `trg_dwh_equipment_history` |
+| `equipment_inventory` | `trg_dwh_equipment_inventory` |
+| `historical_outing_participants` | `trg_dwh_hist_participants` |
+| `locations` | `trg_dwh_locations` |
+| `membership_yearly_status` | `trg_dwh_membership`, `trg_dwh_mys`, `trg_dwh_mys_membre` |
+| `outing_co_instructors` | `trg_dwh_co_instructeurs` |
+| `outings` | `trg_dwh_outings_participation` |
+| `polls` | `trg_dwh_options_sondage_polls`, `trg_dwh_polls` |
+| `profiles` | `trg_dwh_profiles` |
+| `reservations` | `trg_dwh_reservations` |
+| `site_waypoints` | `trg_dwh_waypoints` |
+| `user_roles` | `trg_dwh_user_roles` |
+| `votes` | `trg_dwh_options_sondage_votes`, `trg_dwh_votes` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,3 +139,20 @@ git push origin fix/mon-correctif
 ### Déploiement
 - Chaque merge sur main déclenche un déploiement automatique sur **Vercel**
 - Tester sur la preview Vercel de la PR avant de merger si possible
+
+## Triggers DWH (datawarehouse externe)
+
+Des triggers synchronisent certaines tables vers un DWH PowerBI. Leurs fonctions sont parfois **cassées** (colonnes manquantes). Si un INSERT/UPDATE échoue avec une erreur `column "xxx" of relation "dim_yyy" does not exist`, désactiver le trigger le temps de l'opération :
+
+```sql
+ALTER TABLE <table> DISABLE TRIGGER <trigger>;
+-- opération ici
+ALTER TABLE <table> ENABLE TRIGGER <trigger>;
+```
+
+### Triggers DWH connus par table
+
+| Table | Trigger DWH |
+|-------|-------------|
+| `reservations` | `trg_dwh_reservations` |
+| `locations` | `trg_dwh_locations` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,9 @@ ALTER TABLE <table> ENABLE TRIGGER <trigger>;
 
 ### Triggers DWH connus par table
 
-| Table | Trigger DWH |
-|-------|-------------|
-| `reservations` | `trg_dwh_reservations` |
-| `locations` | `trg_dwh_locations` |
+| Table | Trigger DWH | Table DWH cible |
+|-------|-------------|-----------------|
+| `reservations` | `trg_dwh_reservations` | `fait_participation` |
+| `locations` | `trg_dwh_locations` | `dim_site` |
+| `outing_co_instructors` | `trg_dwh_co_instructeurs` | `fait_co_instructeur` |
+| `membership_yearly_status` | `trg_dwh_membership` | `fait_adhesion` |

--- a/powerbi/database_schema.md
+++ b/powerbi/database_schema.md
@@ -1,6 +1,6 @@
 ﻿# Schéma base de données — Deep Dive Planner
 
-Généré le 2026-06-04 depuis Supabase (projet hyoudezyqbivfthcgpma)
+Généré le 2026-06-04 — mis à jour le 2026-06-05 depuis Supabase (projet hyoudezyqbivfthcgpma)
 
 ## Architecture
 
@@ -11,6 +11,34 @@ Le modèle suit une architecture **DWH (Data Warehouse)** avec :
 - **Tables référentiel** : données de référence stables (apnea_levels, etc.)
 
 Les tables DWH sont synchronisées via des **triggers PostgreSQL** depuis les tables sources.
+
+### Liste complète des triggers DWH
+
+| Table source | Trigger(s) DWH |
+|--------------|----------------|
+| `carpool_passengers` | `trg_dwh_carpool_passengers` |
+| `carpools` | `trg_dwh_carpools` |
+| `club_members_directory` | `trg_dwh_cmd` |
+| `equipment_history` | `trg_dwh_equipment_history` |
+| `equipment_inventory` | `trg_dwh_equipment_inventory` |
+| `historical_outing_participants` | `trg_dwh_hist_participants` |
+| `locations` | `trg_dwh_locations` |
+| `membership_yearly_status` | `trg_dwh_membership`, `trg_dwh_mys`, `trg_dwh_mys_membre` |
+| `outing_co_instructors` | `trg_dwh_co_instructeurs` |
+| `outings` | `trg_dwh_outings_participation` |
+| `polls` | `trg_dwh_options_sondage_polls`, `trg_dwh_polls` |
+| `profiles` | `trg_dwh_profiles` |
+| `reservations` | `trg_dwh_reservations` |
+| `site_waypoints` | `trg_dwh_waypoints` |
+| `user_roles` | `trg_dwh_user_roles` |
+| `votes` | `trg_dwh_options_sondage_votes`, `trg_dwh_votes` |
+
+> ⚠️ Certains triggers sont cassés (colonnes manquantes dans les tables DWH cibles). Si un INSERT/UPDATE échoue avec `column "xxx" of relation "dim_yyy" does not exist`, désactiver le trigger le temps de l'opération :
+> ```sql
+> ALTER TABLE <table> DISABLE TRIGGER <trigger>;
+> -- opération
+> ALTER TABLE <table> ENABLE TRIGGER <trigger>;
+> ```
 
 ---
 

--- a/src/pages/Archives.tsx
+++ b/src/pages/Archives.tsx
@@ -54,6 +54,7 @@ const Archives = () => {
           is_archived,
           organizer_member_id,
           organizer:profiles!outings_organizer_id_fkey(id, first_name, last_name),
+          co_instructors:outing_co_instructors(user_id, profile:profiles(first_name, last_name)),
           location_details:locations(name),
           reservations(
             id,
@@ -475,6 +476,11 @@ const Archives = () => {
                           {outing.displayedOrganizer && (
                             <span className="ml-4">
                               Encadrant: {outing.displayedOrganizer.first_name} {outing.displayedOrganizer.last_name}
+                            </span>
+                          )}
+                          {outing.co_instructors?.length > 0 && (
+                            <span className="ml-2">
+                              · Co-encadrant: {outing.co_instructors[0].profile.first_name} {outing.co_instructors[0].profile.last_name}
                             </span>
                           )}
                         </div>


### PR DESCRIPTION
## Résumé

- **feat: co-encadrant affiché sur les cartes Archives** — le nom du co-encadrant apparaît à côté de l'encadrant principal sur chaque carte de sortie archivée.

- **docs: liste complète des 20 triggers DWH** dans `CLAUDE.md` et `powerbi/database_schema.md` — avec le template SQL `DISABLE/ENABLE TRIGGER` pour contourner les triggers cassés.

## Test plan

- [ ] Vérifier qu'une sortie avec co-encadrant affiche bien "· Co-encadrant: Prénom NOM" dans les Archives

https://claude.ai/code/session_01RpzUVW67nJKJcVq2Zsw58C


---
_Generated by [Claude Code](https://claude.ai/code/session_01RpzUVW67nJKJcVq2Zsw58C)_