### PR TITLE
fix: année par défaut = année courante dans les stats encadrants

### DIFF
--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -49,7 +49,7 @@ const Stats = () => {
   const navigate = useNavigate();
   const { user, loading: authLoading } = useAuth();
   const { isAdmin, loading: roleLoading } = useUserRole();
-  const [selectedYear, setSelectedYear] = useState(2025);
+  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
 
   // Generate available years from 2025 to current year + 1
   const currentYear = new Date().getFullYear();
@@ -159,7 +159,7 @@ const Stats = () => {
       // Use SQL RPC for reliable stats (organizer + co-instructor, regular + historical)
       const { data: rows, error: rpcError } = await supabase
         .rpc("get_encadrant_monthly_stats", { p_year: selectedYear });
-      if (rpcError) throw rpcError;
+if (rpcError) throw rpcError;
 
       (rows ?? []).forEach((row: { profile_id: string; encadrant_name: string; month_index: number; outing_count: number }) => {
         if (!organizerMap.has(row.profile_id)) {


### PR DESCRIPTION
## Problème

L'année par défaut dans la page Stats était figée à `2025`. Les sorties de Karim (Dépollution + Calanque de Niolon) sont en mai **2026** — donc la RPC retournait 1 seule sortie (celle de 2025), pas 2.

## Correctif

`useState(2025)` → `useState(new Date().getFullYear())` — l'année courante s'affiche automatiquement au chargement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpzUVW67nJKJcVq2Zsw58C)_