### PR TITLE
debug: log RPC result stats encadrants

### DIFF
--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -159,7 +159,8 @@ const Stats = () => {
       // Use SQL RPC for reliable stats (organizer + co-instructor, regular + historical)
       const { data: rows, error: rpcError } = await supabase
         .rpc("get_encadrant_monthly_stats", { p_year: selectedYear });
-if (rpcError) throw rpcError;
+      console.log("[STATS DEBUG] year=", selectedYear, "rows=", JSON.stringify(rows), "error=", rpcError);
+      if (rpcError) throw rpcError;
 
       (rows ?? []).forEach((row: { profile_id: string; encadrant_name: string; month_index: number; outing_count: number }) => {
         if (!organizerMap.has(row.profile_id)) {


### PR DESCRIPTION
Debug temporaire pour diagnostiquer pourquoi le total encadrant affiche 1 au lieu de 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpzUVW67nJKJcVq2Zsw58C)_