### PR TITLE
feat: ajouter is_cloturee dans fait_encadrant et fait_co_instructeur

### DIFF
--- a/supabase/migrations/20260605220000_recreate_fait_co_instructeur.sql
+++ b/supabase/migrations/20260605220000_recreate_fait_co_instructeur.sql
@@ -4,16 +4,41 @@
 DROP TABLE IF EXISTS public.fait_co_instructeur CASCADE;
 
 CREATE TABLE public.fait_co_instructeur (
-  sortie_id   UUID NOT NULL REFERENCES public.outings(id) ON DELETE CASCADE,
-  membre_id   UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
-  date_id     DATE,
-  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  sortie_id    UUID NOT NULL REFERENCES public.outings(id) ON DELETE CASCADE,
+  membre_id    UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  date_id      DATE,
+  is_cloturee  BOOLEAN DEFAULT false,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (sortie_id, membre_id)
 );
 
+GRANT SELECT ON public.fait_co_instructeur TO powerbi_reader;
+
+-- Trigger de synchronisation
+CREATE OR REPLACE FUNCTION dwh_sync_fait_co_instructeur()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF (TG_OP = 'DELETE') THEN
+    DELETE FROM fait_co_instructeur
+    WHERE sortie_id = OLD.outing_id AND membre_id = OLD.user_id;
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO fait_co_instructeur (sortie_id, membre_id, date_id, is_cloturee, created_at)
+  SELECT NEW.outing_id, NEW.user_id, o.date_id, (o.date_time < NOW()), now()
+  FROM outings o
+  WHERE o.id = NEW.outing_id
+  ON CONFLICT (sortie_id, membre_id) DO UPDATE
+    SET date_id     = EXCLUDED.date_id,
+        is_cloturee = EXCLUDED.is_cloturee;
+
+  RETURN NEW;
+END;
+$$;
+
 -- Backfill depuis les données existantes
-INSERT INTO public.fait_co_instructeur (sortie_id, membre_id, date_id, created_at)
-SELECT ci.outing_id, ci.user_id, o.date_id, ci.added_at
+INSERT INTO public.fait_co_instructeur (sortie_id, membre_id, date_id, is_cloturee, created_at)
+SELECT ci.outing_id, ci.user_id, o.date_id, (o.date_time < NOW()), ci.added_at
 FROM public.outing_co_instructors ci
 JOIN public.outings o ON o.id = ci.outing_id
 ON CONFLICT (sortie_id, membre_id) DO NOTHING;

--- a/supabase/migrations/20260605230000_fait_encadrant.sql
+++ b/supabase/migrations/20260605230000_fait_encadrant.sql
@@ -1,9 +1,10 @@
 -- Table DWH : sorties organisées par encadrant
 CREATE TABLE public.fait_encadrant (
-  sortie_id   UUID NOT NULL REFERENCES public.outings(id) ON DELETE CASCADE,
-  membre_id   UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
-  date_id     DATE,
-  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  sortie_id    UUID NOT NULL REFERENCES public.outings(id) ON DELETE CASCADE,
+  membre_id    UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  date_id      DATE,
+  is_cloturee  BOOLEAN DEFAULT false,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (sortie_id, membre_id)
 );
 
@@ -20,11 +21,12 @@ BEGIN
   END IF;
 
   IF NEW.organizer_id IS NOT NULL THEN
-    INSERT INTO fait_encadrant (sortie_id, membre_id, date_id, created_at)
-    VALUES (NEW.id, NEW.organizer_id, NEW.date_id, now())
+    INSERT INTO fait_encadrant (sortie_id, membre_id, date_id, is_cloturee, created_at)
+    VALUES (NEW.id, NEW.organizer_id, NEW.date_id, (NEW.date_time < NOW()), now())
     ON CONFLICT (sortie_id, membre_id) DO UPDATE
-      SET membre_id = NEW.organizer_id,
-          date_id   = NEW.date_id;
+      SET membre_id   = NEW.organizer_id,
+          date_id     = NEW.date_id,
+          is_cloturee = (NEW.date_time < NOW());
   END IF;
 
   RETURN NEW;
@@ -36,8 +38,8 @@ CREATE TRIGGER trg_dwh_encadrant
   FOR EACH ROW EXECUTE FUNCTION dwh_sync_fait_encadrant();
 
 -- Backfill depuis les données existantes
-INSERT INTO public.fait_encadrant (sortie_id, membre_id, date_id, created_at)
-SELECT o.id, o.organizer_id, o.date_id, o.created_at
+INSERT INTO public.fait_encadrant (sortie_id, membre_id, date_id, is_cloturee, created_at)
+SELECT o.id, o.organizer_id, o.date_id, (o.date_time < NOW()), o.created_at
 FROM public.outings o
 WHERE o.organizer_id IS NOT NULL
 ON CONFLICT (sortie_id, membre_id) DO NOTHING;

--- a/supabase/migrations/20260605230000_fait_encadrant.sql
+++ b/supabase/migrations/20260605230000_fait_encadrant.sql
@@ -1,0 +1,43 @@
+-- Table DWH : sorties organisées par encadrant
+CREATE TABLE public.fait_encadrant (
+  sortie_id   UUID NOT NULL REFERENCES public.outings(id) ON DELETE CASCADE,
+  membre_id   UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  date_id     DATE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (sortie_id, membre_id)
+);
+
+GRANT SELECT ON public.fait_encadrant TO powerbi_reader;
+
+-- Trigger de synchronisation
+CREATE OR REPLACE FUNCTION dwh_sync_fait_encadrant()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF (TG_OP = 'DELETE') THEN
+    DELETE FROM fait_encadrant
+    WHERE sortie_id = OLD.id AND membre_id = OLD.organizer_id;
+    RETURN OLD;
+  END IF;
+
+  IF NEW.organizer_id IS NOT NULL THEN
+    INSERT INTO fait_encadrant (sortie_id, membre_id, date_id, created_at)
+    VALUES (NEW.id, NEW.organizer_id, NEW.date_id, now())
+    ON CONFLICT (sortie_id, membre_id) DO UPDATE
+      SET membre_id = NEW.organizer_id,
+          date_id   = NEW.date_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_dwh_encadrant
+  AFTER INSERT OR UPDATE OR DELETE ON public.outings
+  FOR EACH ROW EXECUTE FUNCTION dwh_sync_fait_encadrant();
+
+-- Backfill depuis les données existantes
+INSERT INTO public.fait_encadrant (sortie_id, membre_id, date_id, created_at)
+SELECT o.id, o.organizer_id, o.date_id, o.created_at
+FROM public.outings o
+WHERE o.organizer_id IS NOT NULL
+ON CONFLICT (sortie_id, membre_id) DO NOTHING;


### PR DESCRIPTION
Ajout colonne `is_cloturee` (BOOLEAN) dans les deux tables DWH pour filtrer facilement les sorties passées dans Power BI. Triggers mis à jour pour calculer automatiquement `date_time < NOW()`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpzUVW67nJKJcVq2Zsw58C)_