### PR TITLE
fix: liste co-encadrants filtrée sur les encadrants uniquement

### DIFF
--- a/src/components/admin/CreateOutingForm.tsx
+++ b/src/components/admin/CreateOutingForm.tsx
@@ -75,11 +75,12 @@ const CreateOutingForm = ({ prefilledLocationId, prefilledLocationName, onClose 
   const [coInstructorPickerOpen, setCoInstructorPickerOpen] = useState(false);
 
   const { data: allMembers } = useQuery({
-    queryKey: ["profiles-picker"],
+    queryKey: ["encadrants-picker"],
     queryFn: async () => {
       const { data, error } = await supabase
         .from("profiles")
         .select("id, first_name, last_name")
+        .eq("member_status", "Encadrant")
         .order("last_name");
       if (error) throw error;
       return data as { id: string; first_name: string; last_name: string }[];


### PR DESCRIPTION
Filtre la liste du sélecteur co-encadrant sur `member_status = 'Encadrant'` au lieu d'afficher tous les profils.

---
_Generated by [Claude Code](https://claude.ai/code/session_016FihF3HPui4jGMSksNTCdL)_