### PR TITLE
feat: co-encadrant auto-inscrit confirmé à l'ajout

### DIFF
--- a/src/components/admin/CreateOutingForm.tsx
+++ b/src/components/admin/CreateOutingForm.tsx
@@ -255,6 +255,10 @@ const CreateOutingForm = ({ prefilledLocationId, prefilledLocationName, onClose 
               await supabase.from("outing_co_instructors").insert(
                 selectedCoInstructors.map((ci) => ({ outing_id: newOuting.id, user_id: ci.id }))
               );
+              await supabase.from("reservations").upsert(
+                selectedCoInstructors.map((ci) => ({ outing_id: newOuting.id, user_id: ci.id, status: "confirmé" })),
+                { onConflict: "outing_id,user_id", ignoreDuplicates: false }
+              );
             }
             setSelectedCoInstructors([]);
             setCreatedOutingId(newOuting.id);

--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -745,6 +745,11 @@ export const useAddCoInstructor = () => {
         .from("outing_co_instructors")
         .insert({ outing_id: outingId, user_id: userId });
       if (error) throw error;
+      // Auto-confirm co-instructor as participant (upsert to avoid duplicate)
+      await supabase.from("reservations").upsert(
+        { outing_id: outingId, user_id: userId, status: "confirmé" },
+        { onConflict: "outing_id,user_id", ignoreDuplicates: false }
+      );
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["outing"] });
@@ -769,6 +774,13 @@ export const useRemoveCoInstructor = () => {
         .eq("outing_id", outingId)
         .eq("user_id", userId);
       if (error) throw error;
+      // Cancel the auto-confirmed reservation when co-instructor is removed
+      await supabase
+        .from("reservations")
+        .update({ status: "annulé", cancelled_at: new Date().toISOString() })
+        .eq("outing_id", outingId)
+        .eq("user_id", userId)
+        .eq("status", "confirmé");
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["outing"] });

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -77,11 +77,12 @@ const OutingDetail = () => {
   const addCoInstructor = useAddCoInstructor();
   const removeCoInstructor = useRemoveCoInstructor();
   const { data: allMembers } = useQuery({
-    queryKey: ["profiles-picker"],
+    queryKey: ["encadrants-picker"],
     queryFn: async () => {
       const { data, error } = await supabase
         .from("profiles")
         .select("id, first_name, last_name")
+        .eq("member_status", "Encadrant")
         .order("last_name");
       if (error) throw error;
       return data as { id: string; first_name: string; last_name: string }[];


### PR DESCRIPTION
- Ajout co-encadrant → réservation `confirmé` créée automatiquement
- Retrait co-encadrant → réservation passée à `annulé`
- Valable via OutingDetail (ajout manuel) et CreateOutingForm (ajout à la création)
- Inclut aussi : liste filtrée encadrants dans OutingDetail + compteur MesSorties

---
_Generated by [Claude Code](https://claude.ai/code/session_016FihF3HPui4jGMSksNTCdL)_