### PR TITLE
fix: co_instructors dans useCoInstructedOutings → compteur 2/16 correct

### DIFF
--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -703,6 +703,7 @@ export const useCoInstructedOutings = () => {
             *,
             organizer:profiles!outings_organizer_id_fkey(first_name, last_name, apnea_level),
             location_details:locations(id, name, address, maps_url),
+            co_instructors:outing_co_instructors(user_id, profile:profiles(first_name, last_name)),
             reservations(id, user_id, status, carpool_option, carpool_seats, cancelled_at, is_present, created_at)
           )
         `)


### PR DESCRIPTION
Le hook `useCoInstructedOutings` ne chargeait pas `co_instructors`, donc le compteur dans MesSorties ne les incluait jamais. Ajout du select manquant.

---
_Generated by [Claude Code](https://claude.ai/code/session_016FihF3HPui4jGMSksNTCdL)_