### PR TITLE
fix: migration SQL co-encadrants existants → réservation confirmée

### DIFF
--- a/supabase/migrations/20260608180000_auto_confirm_existing_co_instructors.sql
+++ b/supabase/migrations/20260608180000_auto_confirm_existing_co_instructors.sql
@@ -1,0 +1,10 @@
+-- Create confirmed reservations for co-instructors who don't already have one
+INSERT INTO public.reservations (outing_id, user_id, status)
+SELECT ci.outing_id, ci.user_id, 'confirmé'
+FROM public.outing_co_instructors ci
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.reservations r
+  WHERE r.outing_id = ci.outing_id
+    AND r.user_id = ci.user_id
+    AND r.status != 'annulé'
+);


### PR DESCRIPTION
Migration one-shot : crée une réservation `confirmé` pour tous les co-encadrants existants qui n'en ont pas déjà une active.

---
_Generated by [Claude Code](https://claude.ai/code/session_016FihF3HPui4jGMSksNTCdL)_