### PR TITLE
fix: double comptage co-encadrants dans MesSorties

### DIFF
--- a/src/pages/MesSorties.tsx
+++ b/src/pages/MesSorties.tsx
@@ -196,7 +196,7 @@ const MesSorties = () => {
               ) : (
                 <div className="grid gap-4 md:grid-cols-2">
                   {myOutings.map((outing) => {
-                    const confirmedCount = (outing.confirmed_count ?? 0) + (outing.co_instructors?.length ?? 0);
+                    const confirmedCount = outing.confirmed_count ?? 0;
                     const isCoInstructed = outing.organizer_id !== user?.id;
 
                     return (


### PR DESCRIPTION
Suppression du double comptage `co_instructors.length` dans MesSorties — `confirmed_count` inclut déjà les co-encadrants via leurs réservations.

---
_Generated by [Claude Code](https://claude.ai/code/session_016FihF3HPui4jGMSksNTCdL)_