### PR TITLE
feat: saisie en masse matériel — sélecteur de quantité

### DIFF
--- a/src/hooks/useEquipment.ts
+++ b/src/hooks/useEquipment.ts
@@ -187,37 +187,41 @@ export const useAddToInventory = () => {
   const { user } = useAuth();
 
   return useMutation({
-    mutationFn: async ({ catalogId, notes, photoUrl }: { catalogId: string; notes?: string; photoUrl?: string }) => {
+    mutationFn: async ({ catalogId, notes, photoUrl, quantity = 1 }: { catalogId: string; notes?: string; photoUrl?: string; quantity?: number }) => {
       if (!user) throw new Error("Non authentifié");
+
+      const rows = Array.from({ length: quantity }, () => ({
+        catalog_id: catalogId,
+        owner_id: user.id,
+        notes: notes || null,
+        photo_url: photoUrl || null,
+      }));
 
       const { data, error } = await supabase
         .from("equipment_inventory")
-        .insert({
-          catalog_id: catalogId,
-          owner_id: user.id,
-          notes,
-          photo_url: photoUrl,
-        } as any)
-        .select()
-        .single();
+        .insert(rows as any)
+        .select();
 
       if (error) throw error;
 
-      // Log history
-      await supabase.from("equipment_history").insert({
-        inventory_id: data.id,
-        action_type: "acquisition",
-        to_user_id: user.id,
-        new_status: "disponible",
-        created_by: user.id,
-      });
+      // Log history for each item
+      await supabase.from("equipment_history").insert(
+        data.map((item: { id: string }) => ({
+          inventory_id: item.id,
+          action_type: "acquisition",
+          to_user_id: user.id,
+          new_status: "disponible",
+          created_by: user.id,
+        }))
+      );
 
       return data;
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ["my-equipment-inventory"] });
       queryClient.invalidateQueries({ queryKey: ["global-equipment-inventory"] });
-      toast.success("Matériel ajouté à votre inventaire !");
+      const count = Array.isArray(data) ? data.length : 1;
+      toast.success(count > 1 ? `${count} articles ajoutés à votre inventaire !` : "Matériel ajouté à votre inventaire !");
     },
     onError: (error: Error) => {
       toast.error(error.message || "Erreur lors de l'ajout");

--- a/src/pages/Equipment.tsx
+++ b/src/pages/Equipment.tsx
@@ -117,6 +117,7 @@ const MyInventoryTab = () => {
   const [step, setStep] = useState<"select" | "details">("select");
   const [selectedCatalogItem, setSelectedCatalogItem] = useState<typeof catalog extends (infer T)[] ? T : never | null>(null);
   const [notes, setNotes] = useState("");
+  const [quantity, setQuantity] = useState(1);
   const [photoFile, setPhotoFile] = useState<File | null>(null);
   const [photoPreview, setPhotoPreview] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
@@ -177,7 +178,7 @@ const MyInventoryTab = () => {
     }
 
     addToInventory.mutate(
-      { catalogId: selectedCatalogItem.id, notes: notes.trim() || undefined, photoUrl },
+      { catalogId: selectedCatalogItem.id, notes: notes.trim() || undefined, photoUrl, quantity },
       {
         onSuccess: () => {
           resetForm();
@@ -194,6 +195,7 @@ const MyInventoryTab = () => {
     setStep("select");
     setSelectedCatalogItem(null);
     setNotes("");
+    setQuantity(1);
     setPhotoFile(null);
     setPhotoPreview(null);
     setIsUploading(false);
@@ -203,6 +205,7 @@ const MyInventoryTab = () => {
     setStep("select");
     setSelectedCatalogItem(null);
     setNotes("");
+    setQuantity(1);
     setPhotoFile(null);
     setPhotoPreview(null);
   };
@@ -300,9 +303,40 @@ const MyInventoryTab = () => {
                       </Button>
                     </div>
 
+                    {/* Quantity */}
+                    <div className="space-y-2">
+                      <Label>Quantité</Label>
+                      <div className="flex items-center gap-3">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          className="h-9 w-9 shrink-0"
+                          onClick={() => setQuantity(q => Math.max(1, q - 1))}
+                          disabled={quantity <= 1}
+                        >
+                          −
+                        </Button>
+                        <span className="w-10 text-center font-semibold text-lg">{quantity}</span>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          className="h-9 w-9 shrink-0"
+                          onClick={() => setQuantity(q => Math.min(50, q + 1))}
+                          disabled={quantity >= 50}
+                        >
+                          +
+                        </Button>
+                        {quantity > 1 && (
+                          <span className="text-sm text-muted-foreground">→ {quantity} articles créés</span>
+                        )}
+                      </div>
+                    </div>
+
                     {/* Photo upload */}
                     <div className="space-y-2">
-                      <Label>Photo de votre article</Label>
+                      <Label>Photo {quantity > 1 ? "(commune à tous les articles)" : "de votre article"}</Label>
                       {photoPreview ? (
                         <div className="relative">
                           <img
@@ -391,7 +425,7 @@ const MyInventoryTab = () => {
                         disabled={addToInventory.isPending || isUploading}
                       >
                         {(addToInventory.isPending || isUploading) && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                        Ajouter
+                        {quantity > 1 ? `Ajouter ${quantity} articles` : "Ajouter"}
                       </Button>
                     </div>
                   </div>


### PR DESCRIPTION
Ajoute un sélecteur −/+ de quantité (1 à 50) dans le formulaire d'ajout matériel. Si quantité > 1, crée N articles en une seule opération avec des codes uniques distincts. Le bouton affiche "Ajouter X articles" et le toast confirme le nombre créé.

---
_Generated by [Claude Code](https://claude.ai/code/session_016FihF3HPui4jGMSksNTCdL)_