### PR TITLE
fix: photo profil — cache-bust pour afficher la nouvelle image

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -223,9 +223,11 @@ const Profile = () => {
         .from("avatars")
         .getPublicUrl(filePath);
 
+      const avatarUrl = `${urlData.publicUrl}?t=${Date.now()}`;
+
       const { error: updateError } = await supabase
         .from("profiles")
-        .update({ avatar_url: urlData.publicUrl })
+        .update({ avatar_url: avatarUrl })
         .eq("id", user.id);
 
       if (updateError) throw updateError;


### PR DESCRIPTION
Le navigateur mettait en cache l'ancienne photo car l'URL Supabase Storage était identique après chaque upload (même chemin `userId/avatar.ext`). Fix : ajout d'un paramètre `?t=timestamp` pour forcer le rechargement.

---
_Generated by [Claude Code](https://claude.ai/code/session_016FihF3HPui4jGMSksNTCdL)_