### PR TITLE
feat: bouton Proposer un covoiturage depuis la section covoiturage

### DIFF
--- a/src/components/carpool/CarpoolSection.tsx
+++ b/src/components/carpool/CarpoolSection.tsx
@@ -238,6 +238,24 @@ const CarpoolSection = ({ outingId, userReservation, isPast, destinationLat, des
             Proposer un trajet
           </Button>
         )}
+
+        {/* Button for users who didn't declare a carpool at registration */}
+        {!isDriver && !isPassenger && !hasCreatedCarpool && !isPast && !showForm && (
+          <Button
+            variant="outline"
+            className="w-full gap-2"
+            disabled={updateCarpool.isPending}
+            onClick={() =>
+              updateCarpool.mutate(
+                { outingId, carpoolOption: "driver", carpoolSeats: 1 },
+                { onSuccess: () => setShowForm(true) }
+              )
+            }
+          >
+            <Plus className="h-4 w-4" />
+            Proposer un covoiturage
+          </Button>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/carpool/CarpoolSection.tsx
+++ b/src/components/carpool/CarpoolSection.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import { Car, Plus, AlertCircle, List, MapIcon } from "lucide-react";
+import { Car, Plus, AlertCircle, List, MapIcon, X } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useAuth } from "@/contexts/AuthContext";
-import { Reservation, CarpoolOption } from "@/hooks/useOutings";
+import { Reservation, CarpoolOption, useUpdateReservationCarpool } from "@/hooks/useOutings";
 import {
   useCarpools,
   useUserCarpool,
@@ -30,6 +30,7 @@ const CarpoolSection = ({ outingId, userReservation, isPast, destinationLat, des
   const { user } = useAuth();
   const [showForm, setShowForm] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("list");
+  const updateCarpool = useUpdateReservationCarpool();
 
   const { data: carpools, isLoading } = useCarpools(outingId);
   const { data: userCarpool } = useUserCarpool(outingId);
@@ -115,15 +116,27 @@ const CarpoolSection = ({ outingId, userReservation, isPast, destinationLat, des
               <span>
                 👋 Vous avez proposé de conduire ! Configurez votre trajet maintenant.
               </span>
-              <Button
-                variant="ocean"
-                size="sm"
-                className="gap-1 shrink-0"
-                onClick={() => setShowForm(true)}
-              >
-                <Plus className="h-4 w-4" />
-                Configurer
-              </Button>
+              <div className="flex gap-2 shrink-0">
+                <Button
+                  variant="ocean"
+                  size="sm"
+                  className="gap-1"
+                  onClick={() => setShowForm(true)}
+                >
+                  <Plus className="h-4 w-4" />
+                  Configurer
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1"
+                  disabled={updateCarpool.isPending}
+                  onClick={() => updateCarpool.mutate({ outingId, carpoolOption: "none", carpoolSeats: 0 })}
+                >
+                  <X className="h-4 w-4" />
+                  Annuler
+                </Button>
+              </div>
             </AlertDescription>
           </Alert>
         )}

--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -456,6 +456,46 @@ export const useCancelReservation = () => {
   });
 };
 
+export const useUpdateReservationCarpool = () => {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  return useMutation({
+    mutationFn: async ({
+      outingId,
+      carpoolOption,
+      carpoolSeats,
+    }: {
+      outingId: string;
+      carpoolOption: CarpoolOption;
+      carpoolSeats: number;
+    }) => {
+      if (!user) throw new Error("Non connecté");
+
+      const { error } = await supabase
+        .from("reservations")
+        .update({
+          carpool_option: carpoolOption,
+          carpool_seats: carpoolSeats,
+        })
+        .eq("outing_id", outingId)
+        .eq("user_id", user.id);
+
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["outings"] });
+      queryClient.invalidateQueries({ queryKey: ["outing"] });
+      queryClient.invalidateQueries({ queryKey: ["my-reservations"] });
+      queryClient.invalidateQueries({ queryKey: ["outing-participants"] });
+      toast.success("Covoiturage mis à jour");
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Erreur lors de la mise à jour du covoiturage");
+    },
+  });
+};
+
 export const useUpdateReservationPresence = () => {
   const queryClient = useQueryClient();
 

--- a/src/pages/MesSorties.tsx
+++ b/src/pages/MesSorties.tsx
@@ -224,6 +224,9 @@ const MesSorties = () => {
                               </p>
                             </div>
                             <div className="flex items-center gap-2">
+                              {outing.is_staff_only && (
+                                <Badge className="bg-amber-500 text-white text-xs">PRIVÉ STAFF</Badge>
+                              )}
                               {getTypeIcon(outing.outing_type)}
                               <Badge variant="secondary">{outing.outing_type}</Badge>
                             </div>

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -300,6 +300,9 @@ const OutingDetail = () => {
           <div className="mb-8">
             <div className="flex flex-wrap items-center gap-2 mb-2">
               <Badge variant="secondary">{outing.outing_type}</Badge>
+              {outing.is_staff_only && (
+                <Badge className="bg-amber-500 text-white">PRIVÉ STAFF</Badge>
+              )}
               {outing.is_poss_locked && (
                 <Badge className="gap-1 bg-amber-600 text-white">
                   <Lock className="h-3 w-3" />

--- a/src/pages/OutingView.tsx
+++ b/src/pages/OutingView.tsx
@@ -174,6 +174,9 @@ const OutingView = () => {
   );
   const isRegistered = !!userReservation;
 
+  const isCoInstructor = outing.co_instructors?.some(ci => ci.user_id === user.id) ?? false;
+  const coInstructorIds = new Set((outing.co_instructors ?? []).map(ci => ci.user_id));
+
   const handleRegister = () => {
     createReservation.mutate({
       outingId: outing.id,
@@ -317,11 +320,13 @@ const OutingView = () => {
                 {isRegistered ? (
                   <div className="space-y-4">
                     <div className="flex items-center gap-2 text-emerald-600">
-                      <UserPlus className="h-5 w-5" />
+                      {isCoInstructor ? <Shield className="h-5 w-5" /> : <UserPlus className="h-5 w-5" />}
                       <span className="font-medium">
                         {userReservation?.status === "en_attente"
                           ? "Vous êtes sur liste d'attente"
-                          : "Vous êtes inscrit(e) à cette sortie"}
+                          : isCoInstructor
+                            ? "Vous êtes coencadrant(e) de cette sortie"
+                            : "Vous êtes inscrit(e) à cette sortie"}
                       </span>
                     </div>
                     <AlertDialog>
@@ -466,6 +471,7 @@ const OutingView = () => {
                     const profile = reservation.profile;
                     const initials = profile ? `${profile.first_name?.[0] ?? ""}${profile.last_name?.[0] ?? ""}` : "?";
                     const isOrg = reservation.user_id === organizerId;
+                    const isCoInstr = coInstructorIds.has(reservation.user_id);
                     const levelInfo = apneaLevelMap.get(profile?.apnea_level ?? "");
                     const isInstructor = levelInfo?.is_instructor ?? false;
                     const depth = !isInstructor ? extractDepth(levelInfo?.prerogatives ?? null) : null;
@@ -476,17 +482,19 @@ const OutingView = () => {
                         className={`flex items-center gap-3 rounded-lg border p-3 ${
                           isOrg
                             ? "border-amber-300 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-700"
-                            : "border-border bg-muted/30"
+                            : isCoInstr
+                              ? "border-blue-300 bg-blue-50 dark:bg-blue-950/20 dark:border-blue-700"
+                              : "border-border bg-muted/30"
                         }`}
                       >
                         <div className="relative">
                           <Avatar className="h-10 w-10">
                             <AvatarImage src={profile?.avatar_url ?? undefined} />
-                            <AvatarFallback className={`text-sm ${isOrg ? "bg-amber-200 text-amber-800" : "bg-primary/10 text-primary"}`}>
+                            <AvatarFallback className={`text-sm ${isOrg ? "bg-amber-200 text-amber-800" : isCoInstr ? "bg-blue-200 text-blue-800" : "bg-primary/10 text-primary"}`}>
                               {initials}
                             </AvatarFallback>
                           </Avatar>
-                          {isInstructor && (
+                          {(isInstructor || isCoInstr) && (
                             <div className="absolute -bottom-1 -right-1 h-5 w-5 rounded-full bg-amber-500 flex items-center justify-center shadow-sm" title="Encadrant">
                               <Shield className="h-3 w-3 text-white" />
                             </div>
@@ -499,6 +507,9 @@ const OutingView = () => {
                             </p>
                             {isOrg && (
                               <Badge className="bg-amber-500 text-white text-[10px] px-1.5 py-0">Organisateur</Badge>
+                            )}
+                            {isCoInstr && !isOrg && (
+                              <Badge className="bg-blue-500 text-white text-[10px] px-1.5 py-0">Coencadrant</Badge>
                             )}
                           </div>
                           <div className="flex items-center gap-2 mt-0.5 flex-wrap">

--- a/src/pages/OutingView.tsx
+++ b/src/pages/OutingView.tsx
@@ -42,6 +42,7 @@ import {
   useOuting,
   useCreateReservation,
   useCancelReservation,
+  useUpdateReservationCarpool,
   CarpoolOption,
 } from "@/hooks/useOutings";
 import { supabase } from "@/integrations/supabase/client";
@@ -92,10 +93,14 @@ const OutingView = () => {
 
   const createReservation = useCreateReservation();
   const cancelReservation = useCancelReservation();
+  const updateCarpool = useUpdateReservationCarpool();
   const { data: apneaLevels } = useApneaLevels();
 
   const [carpoolOption, setCarpoolOption] = useState<CarpoolOption>("none");
   const [carpoolSeats, setCarpoolSeats] = useState(1);
+  const [showCarpoolEdit, setShowCarpoolEdit] = useState(false);
+  const [editCarpoolOption, setEditCarpoolOption] = useState<CarpoolOption>("none");
+  const [editCarpoolSeats, setEditCarpoolSeats] = useState(1);
 
   const handleCarpoolOptionChange = (value: CarpoolOption) => {
     setCarpoolOption(value);
@@ -176,6 +181,24 @@ const OutingView = () => {
 
   const isCoInstructor = outing.co_instructors?.some(ci => ci.user_id === user.id) ?? false;
   const coInstructorIds = new Set((outing.co_instructors ?? []).map(ci => ci.user_id));
+
+  const handleOpenCarpoolEdit = () => {
+    setEditCarpoolOption((userReservation?.carpool_option as CarpoolOption) ?? "none");
+    setEditCarpoolSeats(userReservation?.carpool_seats || 1);
+    setShowCarpoolEdit(true);
+  };
+
+  const handleCarpoolUpdate = () => {
+    if (!outing) return;
+    updateCarpool.mutate(
+      {
+        outingId: outing.id,
+        carpoolOption: editCarpoolOption,
+        carpoolSeats: editCarpoolOption === "driver" ? editCarpoolSeats : 0,
+      },
+      { onSuccess: () => setShowCarpoolEdit(false) }
+    );
+  };
 
   const handleRegister = () => {
     createReservation.mutate({
@@ -351,6 +374,97 @@ const OutingView = () => {
                         </AlertDialogFooter>
                       </AlertDialogContent>
                     </AlertDialog>
+
+                    {/* Carpool option — editable after registration */}
+                    <div className="border-t pt-3">
+                      {showCarpoolEdit ? (
+                        <div className="space-y-3">
+                          <Label className="flex items-center gap-2 text-sm font-medium">
+                            <Car className="h-4 w-4" />
+                            Modifier le covoiturage
+                          </Label>
+                          <RadioGroup
+                            value={editCarpoolOption}
+                            onValueChange={(v) => setEditCarpoolOption(v as CarpoolOption)}
+                            className="space-y-2"
+                          >
+                            <div className="flex items-center space-x-2">
+                              <RadioGroupItem value="none" id="edit-none" />
+                              <Label htmlFor="edit-none" className="font-normal">Pas de covoiturage</Label>
+                            </div>
+                            <div className="flex items-center space-x-2">
+                              <RadioGroupItem value="driver" id="edit-driver" />
+                              <Label htmlFor="edit-driver" className="font-normal">Je propose des places</Label>
+                            </div>
+                            <div className="flex items-center space-x-2">
+                              <RadioGroupItem value="passenger" id="edit-passenger" />
+                              <Label htmlFor="edit-passenger" className="font-normal">Je cherche une place</Label>
+                            </div>
+                          </RadioGroup>
+                          {editCarpoolOption === "driver" && (
+                            <div className="space-y-2">
+                              <Label className="text-sm">Places disponibles</Label>
+                              <div className="flex items-center gap-4">
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="icon"
+                                  className="h-9 w-9 rounded-full"
+                                  onClick={() => setEditCarpoolSeats(Math.max(1, editCarpoolSeats - 1))}
+                                  disabled={editCarpoolSeats <= 1}
+                                >
+                                  <Minus className="h-4 w-4" />
+                                </Button>
+                                <span className="text-2xl font-bold w-8 text-center">{editCarpoolSeats}</span>
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="icon"
+                                  className="h-9 w-9 rounded-full"
+                                  onClick={() => setEditCarpoolSeats(Math.min(8, editCarpoolSeats + 1))}
+                                  disabled={editCarpoolSeats >= 8}
+                                >
+                                  <Plus className="h-4 w-4" />
+                                </Button>
+                              </div>
+                            </div>
+                          )}
+                          <div className="flex gap-2">
+                            <Button
+                              variant="ocean"
+                              size="sm"
+                              className="flex-1"
+                              onClick={handleCarpoolUpdate}
+                              disabled={updateCarpool.isPending}
+                            >
+                              {updateCarpool.isPending ? "Enregistrement..." : "Enregistrer"}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setShowCarpoolEdit(false)}
+                            >
+                              Annuler
+                            </Button>
+                          </div>
+                        </div>
+                      ) : (
+                        <button
+                          className="w-full flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
+                          onClick={handleOpenCarpoolEdit}
+                        >
+                          <Car className="h-4 w-4 shrink-0" />
+                          <span>
+                            {userReservation?.carpool_option === "driver"
+                              ? `Je propose ${userReservation.carpool_seats || 1} place(s)`
+                              : userReservation?.carpool_option === "passenger"
+                                ? "Je cherche une place"
+                                : "Pas de covoiturage"}
+                          </span>
+                          <span className="ml-auto text-xs underline underline-offset-2">Modifier</span>
+                        </button>
+                      )}
+                    </div>
                   </div>
                 ) : (
                   <div className="space-y-6">

--- a/src/pages/Reservations.tsx
+++ b/src/pages/Reservations.tsx
@@ -96,6 +96,9 @@ const Reservations = () => {
                                 <Badge variant="secondary">
                                   {reservation.outing?.outing_type}
                                 </Badge>
+                                {reservation.outing?.is_staff_only && (
+                                  <Badge className="bg-amber-500 text-white text-xs">PRIVÉ STAFF</Badge>
+                                )}
                                 {reservation.status === "en_attente" && (
                                   <Badge variant="outline" className="border-amber-500 text-amber-600">
                                     Liste d'attente


### PR DESCRIPTION
Un utilisateur inscrit sans option covoiturage peut maintenant proposer un trajet directement depuis la section covoiturage, sans devoir remonter à la section inscription. Un clic passe `carpool_option` à "driver" et ouvre le formulaire de configuration du trajet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb6aY17AJhbGqfBU5YHbYG)_