### PR TITLE
fix: phrase d'explication pour les options de RDV covoiturage

### DIFF
--- a/src/components/carpool/CarpoolForm.tsx
+++ b/src/components/carpool/CarpoolForm.tsx
@@ -220,6 +220,9 @@ const CarpoolForm = ({
               <MapPin className="h-3 w-3" />
               Point de rendez-vous *
             </Label>
+            <p className="text-xs text-muted-foreground">
+              Indiquez votre point de départ par l'une de ces trois options :
+            </p>
 
             {/* Option 1 : carte interactive */}
             {(destinationLat && destinationLng) && (


### PR DESCRIPTION
Ajout d'une courte phrase sous le label "Point de rendez-vous" pour indiquer que les trois options sont des alternatives.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb6aY17AJhbGqfBU5YHbYG)_