### PR TITLE
fix: afficher le point de départ du conducteur sur la carte covoiturage

### DIFF
--- a/src/components/carpool/CarpoolCard.tsx
+++ b/src/components/carpool/CarpoolCard.tsx
@@ -159,17 +159,33 @@ const CarpoolCard = ({
         {/* Meeting point with clickable map link */}
         <div className="mt-4 flex items-center gap-2 text-sm p-3 bg-muted/50 rounded-lg">
           <MapPin className="h-5 w-5 text-primary shrink-0" />
-          <span className="text-foreground flex-1">{carpool.meeting_point}</span>
-          {carpool.maps_link && (
+          {carpool.meeting_point ? (
+            <>
+              <span className="text-foreground flex-1">{carpool.meeting_point}</span>
+              {carpool.maps_link && (
+                <a
+                  href={carpool.maps_link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-primary hover:text-primary/80 transition-colors font-medium"
+                >
+                  <ExternalLink className="h-4 w-4" />
+                  <span className="text-xs">GPS</span>
+                </a>
+              )}
+            </>
+          ) : carpool.maps_link ? (
             <a
               href={carpool.maps_link}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-1 text-primary hover:text-primary/80 transition-colors font-medium"
+              className="flex-1 flex items-center gap-1 text-primary hover:text-primary/80 transition-colors font-medium"
             >
-              <ExternalLink className="h-4 w-4" />
-              <span className="text-xs">GPS</span>
+              <span>Voir le point de départ sur la carte</span>
+              <ExternalLink className="h-4 w-4 shrink-0" />
             </a>
+          ) : (
+            <span className="text-muted-foreground italic">Point de départ non précisé</span>
           )}
         </div>
 

--- a/src/components/carpool/CarpoolForm.tsx
+++ b/src/components/carpool/CarpoolForm.tsx
@@ -220,13 +220,10 @@ const CarpoolForm = ({
               <MapPin className="h-3 w-3" />
               Point de rendez-vous *
             </Label>
-            <p className="text-xs text-muted-foreground">
-              Indiquez votre point de départ par l'une de ces trois options :
-            </p>
-
             {/* Option 1 : carte interactive */}
             {(destinationLat && destinationLng) && (
               <>
+                <p className="text-xs font-medium text-muted-foreground">Option 1 — Choisir sur la carte</p>
                 <Button
                   type="button"
                   variant={showMap ? "secondary" : "outline"}
@@ -234,7 +231,7 @@ const CarpoolForm = ({
                   onClick={() => setShowMap(!showMap)}
                 >
                   <Map className="h-4 w-4" />
-                  {showMap ? "Masquer la carte" : "📍 Choisir sur la carte"}
+                  {showMap ? "Masquer la carte" : "📍 Ouvrir la carte"}
                 </Button>
                 {showMap && (
                   <CarpoolMapPicker
@@ -253,6 +250,9 @@ const CarpoolForm = ({
             )}
 
             {/* Option 2 : saisie libre */}
+            <p className="text-xs font-medium text-muted-foreground">
+              {(destinationLat && destinationLng) ? "Option 2" : "Option 1"} — Saisie libre
+            </p>
             <Input
               id="meetingPoint"
               placeholder="Ex: Parking du supermarché, 12 rue de la Gare"
@@ -267,10 +267,13 @@ const CarpoolForm = ({
             </div>
 
             {/* Option 3 : lien Google Maps */}
+            <p className="text-xs font-medium text-muted-foreground">
+              {(destinationLat && destinationLng) ? "Option 3" : "Option 2"} — Lien Google Maps
+            </p>
             <Input
               id="mapsLink"
               type="url"
-              placeholder="Lien Google Maps (maps.google.com/...)"
+              placeholder="https://maps.google.com/..."
               value={mapsLink}
               onChange={(e) => setMapsLink(e.target.value)}
             />

--- a/src/components/carpool/CarpoolMapView.tsx
+++ b/src/components/carpool/CarpoolMapView.tsx
@@ -288,7 +288,20 @@ const CarpoolMapView = ({
 
           <div className="flex items-center gap-2 text-sm mb-3 p-2 bg-muted/50 rounded-lg">
             <MapPin className="h-4 w-4 text-primary shrink-0" />
-            <span className="truncate">{selectedCarpool.meeting_point}</span>
+            {selectedCarpool.meeting_point ? (
+              <span className="truncate">{selectedCarpool.meeting_point}</span>
+            ) : selectedCarpool.maps_link ? (
+              <a
+                href={selectedCarpool.maps_link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline truncate"
+              >
+                Voir sur Google Maps
+              </a>
+            ) : (
+              <span className="text-muted-foreground italic">Point non précisé</span>
+            )}
           </div>
 
           <div className="flex items-center justify-between">

--- a/src/components/carpool/CarpoolSection.tsx
+++ b/src/components/carpool/CarpoolSection.tsx
@@ -186,7 +186,7 @@ const CarpoolSection = ({ outingId, userReservation, isPast, destinationLat, des
         {carpools && carpools.length > 0 ? (
           viewMode === "map" && hasCarpoolsForMap ? (
             <CarpoolMapView
-              carpools={carpools.filter((c) => c.driver_id !== user.id)}
+              carpools={carpools}
               outingId={outingId}
               destinationLat={destinationLat}
               destinationLng={destinationLng}

--- a/src/components/carpool/CarpoolSection.tsx
+++ b/src/components/carpool/CarpoolSection.tsx
@@ -114,7 +114,7 @@ const CarpoolSection = ({ outingId, userReservation, isPast, destinationLat, des
             <AlertCircle className="h-4 w-4 text-primary" />
             <AlertDescription className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
               <span>
-                👋 Vous avez proposé de conduire ! Configurez votre trajet maintenant.
+                🌿 Merci de proposer un covoiturage ! Configurez votre trajet pour que vos équipiers puissent vous rejoindre.
               </span>
               <div className="flex gap-2 shrink-0">
                 <Button


### PR DESCRIPTION
Le trajet du conducteur était filtré avant d'être passé à CarpoolMapView, donc son point de départ n'apparaissait jamais sur la carte. Suppression du filtre : le marqueur amber s'affiche maintenant pour le propre trajet. Le bouton de réservation reste bien masqué (guard `driver_id !== user.id` déjà en place). Bonus : le popup affiche un lien "Voir sur Google Maps" quand seul le lien Maps est renseigné.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb6aY17AJhbGqfBU5YHbYG)_