### PR TITLE
feat: agenda du club via Google Calendar Team Oxygen

### DIFF
--- a/src/components/calendar/ClubCalendarWidget.tsx
+++ b/src/components/calendar/ClubCalendarWidget.tsx
@@ -1,0 +1,108 @@
+import { Calendar, MapPin, ExternalLink } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useClubCalendar, ClubCalendarEvent } from "@/hooks/useClubCalendar";
+
+const CALENDAR_PUBLIC_URL =
+  "https://calendar.google.com/calendar/embed?src=5b622c3d759c30b0a6558d985d73259efcba11279c9934ea1a665a34e47b8c07%40group.calendar.google.com&ctz=Europe%2FBrussels";
+
+const isMultiDay = (event: ClubCalendarEvent): boolean => {
+  if (!event.endDate || !event.isAllDay) return false;
+  const diff = new Date(event.endDate).getTime() - new Date(event.startDate).getTime();
+  return diff > 24 * 60 * 60 * 1000;
+};
+
+const formatDateRange = (event: ClubCalendarEvent): string => {
+  const start = new Date(event.startDate);
+  const opts: Intl.DateTimeFormatOptions = { day: "numeric", month: "long", timeZone: "UTC" };
+
+  if (!isMultiDay(event) || !event.endDate) {
+    if (event.isAllDay) {
+      return start.toLocaleDateString("fr-FR", { weekday: "long", day: "numeric", month: "long", timeZone: "UTC" });
+    }
+    return start.toLocaleString("fr-FR", { weekday: "short", day: "numeric", month: "long", hour: "2-digit", minute: "2-digit" });
+  }
+
+  // End is exclusive for all-day events → subtract 1 day
+  const endExclusive = new Date(event.endDate);
+  const endInclusive = new Date(endExclusive.getTime() - 24 * 60 * 60 * 1000);
+  return `${start.toLocaleDateString("fr-FR", opts)} → ${endInclusive.toLocaleDateString("fr-FR", opts)}`;
+};
+
+const ClubCalendarWidget = () => {
+  const { data: events, isLoading, error } = useClubCalendar();
+
+  if (isLoading || error || !events || events.length === 0) return null;
+
+  const upcoming = events.slice(0, 6);
+
+  return (
+    <Card className="shadow-card">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Calendar className="h-4 w-4 text-primary" />
+            Agenda du club
+          </CardTitle>
+          <Button variant="ghost" size="sm" asChild className="gap-1.5 text-xs text-muted-foreground h-7 px-2">
+            <a href={CALENDAR_PUBLIC_URL} target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="h-3 w-3" />
+              Voir tout
+            </a>
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-2 space-y-0">
+        {upcoming.map((event, idx) => {
+          const startDate = new Date(event.startDate);
+          const multi = isMultiDay(event);
+
+          return (
+            <div
+              key={event.id}
+              className={`flex items-start gap-3 py-2.5 ${idx < upcoming.length - 1 ? "border-b border-border/40" : ""}`}
+            >
+              {/* Date badge */}
+              <div className="shrink-0 w-10 text-center">
+                <p className="text-[10px] font-medium text-muted-foreground uppercase leading-none">
+                  {startDate.toLocaleDateString("fr-FR", { month: "short", timeZone: "UTC" })}
+                </p>
+                <p className="text-xl font-bold leading-tight text-foreground">
+                  {startDate.toLocaleDateString("fr-FR", { day: "numeric", timeZone: "UTC" })}
+                </p>
+              </div>
+
+              {/* Content */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <p className="text-sm font-semibold text-foreground leading-snug">{event.title}</p>
+                  {multi && (
+                    <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4 shrink-0">
+                      Plusieurs jours
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground mt-0.5">{formatDateRange(event)}</p>
+                {event.location && (
+                  <div className="flex items-center gap-1 mt-0.5">
+                    <MapPin className="h-3 w-3 text-muted-foreground/70 shrink-0" />
+                    <p className="text-xs text-muted-foreground truncate">{event.location}</p>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+
+        {events.length > 6 && (
+          <p className="text-xs text-center text-muted-foreground pt-2">
+            +{events.length - 6} autre{events.length - 6 > 1 ? "s" : ""} événement{events.length - 6 > 1 ? "s" : ""}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ClubCalendarWidget;

--- a/src/hooks/useClubCalendar.ts
+++ b/src/hooks/useClubCalendar.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+
+export interface ClubCalendarEvent {
+  id: string;
+  title: string;
+  startDate: string;
+  endDate: string | null;
+  isAllDay: boolean;
+  location: string | null;
+  description: string | null;
+}
+
+export const useClubCalendar = () => {
+  return useQuery({
+    queryKey: ["club-calendar"],
+    queryFn: async () => {
+      const { data, error } = await supabase.functions.invoke("get-club-calendar");
+      if (error) throw error;
+      return data as ClubCalendarEvent[];
+    },
+    staleTime: 60 * 60 * 1000,  // 1h cache
+    gcTime: 2 * 60 * 60 * 1000,
+    retry: 1,
+  });
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,6 +12,7 @@ import HistoricalOutingForm from "@/components/outings/HistoricalOutingForm";
 import { useCarpoolCounts } from "@/hooks/useCarpoolCounts";
 import LandingPage from "@/pages/LandingPage";
 import ActivePollsBanner from "@/components/sondages/ActivePollsBanner";
+import ClubCalendarWidget from "@/components/calendar/ClubCalendarWidget";
 
 const Index = () => {
   // ── Tous les hooks en premier (règle des hooks React) ─────────────
@@ -127,6 +128,13 @@ const Index = () => {
               ))}
             </div>
           )}
+        </div>
+      </section>
+
+      {/* Club calendar from Google Calendar */}
+      <section className="pb-10">
+        <div className="container mx-auto px-4 max-w-lg">
+          <ClubCalendarWidget />
         </div>
       </section>
 

--- a/supabase/functions/get-club-calendar/index.ts
+++ b/supabase/functions/get-club-calendar/index.ts
@@ -1,0 +1,157 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+const CALENDAR_ID = "5b622c3d759c30b0a6558d985d73259efcba11279c9934ea1a665a34e47b8c07@group.calendar.google.com";
+const ICS_URL = `https://calendar.google.com/calendar/ical/${encodeURIComponent(CALENDAR_ID)}/public/basic.ics`;
+
+interface CalendarEvent {
+  id: string;
+  title: string;
+  startDate: string;
+  endDate: string | null;
+  isAllDay: boolean;
+  location: string | null;
+  description: string | null;
+}
+
+function parseICSDate(dateStr: string): Date {
+  if (dateStr.length === 8) {
+    // All-day: YYYYMMDD — treat as UTC midnight
+    return new Date(Date.UTC(
+      parseInt(dateStr.slice(0, 4)),
+      parseInt(dateStr.slice(4, 6)) - 1,
+      parseInt(dateStr.slice(6, 8))
+    ));
+  }
+  // DateTime: YYYYMMDDTHHMMSS[Z] or floating
+  const year = parseInt(dateStr.slice(0, 4));
+  const month = parseInt(dateStr.slice(4, 6)) - 1;
+  const day = parseInt(dateStr.slice(6, 8));
+  const hour = parseInt(dateStr.slice(9, 11));
+  const min = parseInt(dateStr.slice(11, 13));
+  const sec = parseInt(dateStr.slice(13, 15) || "0");
+
+  if (dateStr.endsWith("Z")) {
+    return new Date(Date.UTC(year, month, day, hour, min, sec));
+  }
+  // Floating/local — treat as Europe/Paris (UTC+2 in summer, approximate)
+  return new Date(Date.UTC(year, month, day, hour - 2, min, sec));
+}
+
+function unescapeICS(value: string): string {
+  return value
+    .replace(/\\n/g, "\n")
+    .replace(/\\,/g, ",")
+    .replace(/\\;/g, ";")
+    .replace(/\\\\/g, "\\");
+}
+
+function parseICS(icsText: string): CalendarEvent[] {
+  // Unfold folded lines (CRLF + whitespace = continuation)
+  const unfolded = icsText.replace(/\r\n[ \t]/g, "").replace(/\n[ \t]/g, "");
+  const lines = unfolded.split(/\r\n|\n/);
+
+  const events: CalendarEvent[] = [];
+  let inEvent = false;
+  let props: Record<string, string> = {};
+
+  for (const line of lines) {
+    if (line === "BEGIN:VEVENT") {
+      inEvent = true;
+      props = {};
+    } else if (line === "END:VEVENT") {
+      inEvent = false;
+
+      try {
+        const uid = props["UID"] || crypto.randomUUID();
+        const summary = unescapeICS(props["SUMMARY"] || "Événement");
+        const location = props["LOCATION"] ? unescapeICS(props["LOCATION"]) : null;
+        const description = props["DESCRIPTION"] ? unescapeICS(props["DESCRIPTION"]) : null;
+
+        // DTSTART: prefer VALUE=DATE key, fall back to bare DTSTART
+        const dtstartRaw = props["DTSTART;VALUE=DATE"] ?? props["DTSTART"];
+        if (!dtstartRaw) continue;
+
+        const isAllDay = dtstartRaw.length === 8 || !!props["DTSTART;VALUE=DATE"];
+        const startDate = parseICSDate(dtstartRaw);
+
+        const dtendRaw = props["DTEND;VALUE=DATE"] ?? props["DTEND"];
+        const endDate = dtendRaw ? parseICSDate(dtendRaw) : null;
+
+        events.push({
+          id: uid,
+          title: summary,
+          startDate: startDate.toISOString(),
+          endDate: endDate?.toISOString() ?? null,
+          isAllDay,
+          location,
+          description,
+        });
+      } catch (e) {
+        console.warn("Failed to parse VEVENT:", e);
+      }
+    } else if (inEvent) {
+      const colonIdx = line.indexOf(":");
+      if (colonIdx === -1) continue;
+
+      const propKey = line.slice(0, colonIdx);
+      const propValue = line.slice(colonIdx + 1);
+
+      // Store with full key (e.g. "DTSTART;VALUE=DATE") AND bare name (e.g. "DTSTART")
+      props[propKey] = propValue;
+      const bareName = propKey.split(";")[0];
+      if (bareName !== propKey && !props[bareName]) {
+        props[bareName] = propValue;
+      }
+    }
+  }
+
+  return events;
+}
+
+const handler = async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const response = await fetch(ICS_URL, {
+      headers: { "User-Agent": "MyOxygen-TeamOxygen/1.0" },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Google Calendar returned ${response.status}`);
+    }
+
+    const icsText = await response.text();
+    const events = parseICS(icsText);
+
+    // Keep events from 7 days ago to 6 months ahead
+    const past = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const future = new Date(Date.now() + 180 * 24 * 60 * 60 * 1000);
+
+    const filtered = events
+      .filter((e) => {
+        const start = new Date(e.startDate);
+        return start >= past && start <= future;
+      })
+      .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime());
+
+    return new Response(JSON.stringify(filtered), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("get-club-calendar error:", message);
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+};
+
+serve(handler);


### PR DESCRIPTION
## Summary

- Nouvelle Edge Function `get-club-calendar` : fetch le flux ICS public du calendrier Google Team Oxygen, parse les événements et les retourne en JSON (7 jours passés + 6 mois à venir)
- Hook `useClubCalendar` : React Query avec 1h de cache
- Composant `ClubCalendarWidget` : carte compacte sur la home affichant les prochains événements (date, titre, lieu, badge "Plusieurs jours" pour les events multi-jours)
- Intégration dans `Index.tsx` sous la liste des sorties

## Test plan

- [ ] La carte "Agenda du club" apparaît sur la home avec les événements Google Calendar Team Oxygen
- [ ] Les événements multi-jours (ex: BLUEWEEK) affichent la plage de dates
- [ ] Le lien "Voir tout" ouvre le Google Calendar Team Oxygen
- [ ] La carte ne s'affiche pas si aucun événement (erreur réseau ou calendrier vide)

https://claude.ai/code/session_01Wb6aY17AJhbGqfBU5YHbYG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb6aY17AJhbGqfBU5YHbYG)_