### PR TITLE
fix: alignement widget agenda du club

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -128,13 +128,10 @@ const Index = () => {
               ))}
             </div>
           )}
-        </div>
-      </section>
-
-      {/* Club calendar from Google Calendar */}
-      <section className="pb-10">
-        <div className="container mx-auto px-4 max-w-lg">
-          <ClubCalendarWidget />
+          {/* Club calendar from Google Calendar */}
+          <div className="mt-10">
+            <ClubCalendarWidget />
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
Le widget "Agenda du club" était dans son propre container avec `max-w-lg`, ce qui le décalait visuellement par rapport à la grille des sorties. Déplacé à l'intérieur du même container que les sorties.

https://claude.ai/code/session_01Wb6aY17AJhbGqfBU5YHbYG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb6aY17AJhbGqfBU5YHbYG)_