### PR TITLE
fix: agenda du club affiché avant les sorties

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -65,6 +65,13 @@ const Index = () => {
 
       <ActivePollsBanner />
 
+      {/* Club calendar from Google Calendar */}
+      <section className="pt-8 pb-0">
+        <div className="container mx-auto px-4">
+          <ClubCalendarWidget />
+        </div>
+      </section>
+
       {/* Outings Section */}
       <section className="py-12">
         <div className="container mx-auto px-4">
@@ -128,10 +135,6 @@ const Index = () => {
               ))}
             </div>
           )}
-          {/* Club calendar from Google Calendar */}
-          <div className="mt-10">
-            <ClubCalendarWidget />
-          </div>
         </div>
       </section>
 


### PR DESCRIPTION
Déplace le widget "Agenda du club" au-dessus de la liste des sorties, entre la bannière des sondages et la section sorties.

https://claude.ai/code/session_01Wb6aY17AJhbGqfBU5YHbYG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb6aY17AJhbGqfBU5YHbYG)_