### PR TITLE
fix: agenda du club repassé sous les sorties

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -65,13 +65,6 @@ const Index = () => {
 
       <ActivePollsBanner />
 
-      {/* Club calendar from Google Calendar */}
-      <section className="pt-8 pb-0">
-        <div className="container mx-auto px-4">
-          <ClubCalendarWidget />
-        </div>
-      </section>
-
       {/* Outings Section */}
       <section className="py-12">
         <div className="container mx-auto px-4">
@@ -135,6 +128,11 @@ const Index = () => {
               ))}
             </div>
           )}
+
+          {/* Club calendar from Google Calendar */}
+          <div className="mt-10">
+            <ClubCalendarWidget />
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
Les sorties restent prioritaires en haut de page. L'agenda du club repasse en bas, après la grille des sorties.

https://claude.ai/code/session_01Wb6aY17AJhbGqfBU5YHbYG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb6aY17AJhbGqfBU5YHbYG)_