### PR TITLE
fix: badges covoiturage cohérents (Inscrit covoit. + places restantes)

### DIFF
--- a/src/hooks/useCarpools.ts
+++ b/src/hooks/useCarpools.ts
@@ -386,10 +386,18 @@ export const useBookCarpool = () => {
         });
 
       if (error) throw error;
+
+      // Clear "looking for carpool" status now that the passenger has a seat
+      await supabase
+        .from("reservations")
+        .update({ carpool_option: "none" })
+        .eq("user_id", user.id)
+        .eq("outing_id", outingId);
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ["carpools", variables.outingId] });
       queryClient.invalidateQueries({ queryKey: ["user-carpool-booking", variables.outingId] });
+      queryClient.invalidateQueries({ queryKey: ["outings"] });
       toast.success("Place réservée !");
     },
     onError: (error: Error) => {
@@ -412,10 +420,18 @@ export const useCancelCarpoolBooking = () => {
         .eq("id", bookingId);
 
       if (error) throw error;
+
+      // Restore "looking for carpool" status when cancelling
+      await supabase
+        .from("reservations")
+        .update({ carpool_option: "passenger" })
+        .eq("user_id", user.id)
+        .eq("outing_id", outingId);
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ["carpools", variables.outingId] });
       queryClient.invalidateQueries({ queryKey: ["user-carpool-booking", variables.outingId] });
+      queryClient.invalidateQueries({ queryKey: ["outings"] });
       toast.success("Réservation annulée");
     },
     onError: (error: Error) => {

--- a/src/hooks/useCarpools.ts
+++ b/src/hooks/useCarpools.ts
@@ -386,18 +386,10 @@ export const useBookCarpool = () => {
         });
 
       if (error) throw error;
-
-      // Clear "looking for carpool" status now that the passenger has a seat
-      await supabase
-        .from("reservations")
-        .update({ carpool_option: "none" })
-        .eq("user_id", user.id)
-        .eq("outing_id", outingId);
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ["carpools", variables.outingId] });
       queryClient.invalidateQueries({ queryKey: ["user-carpool-booking", variables.outingId] });
-      queryClient.invalidateQueries({ queryKey: ["outings"] });
       toast.success("Place réservée !");
     },
     onError: (error: Error) => {
@@ -420,18 +412,10 @@ export const useCancelCarpoolBooking = () => {
         .eq("id", bookingId);
 
       if (error) throw error;
-
-      // Restore "looking for carpool" status when cancelling
-      await supabase
-        .from("reservations")
-        .update({ carpool_option: "passenger" })
-        .eq("user_id", user.id)
-        .eq("outing_id", outingId);
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ["carpools", variables.outingId] });
       queryClient.invalidateQueries({ queryKey: ["user-carpool-booking", variables.outingId] });
-      queryClient.invalidateQueries({ queryKey: ["outings"] });
       toast.success("Réservation annulée");
     },
     onError: (error: Error) => {

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -43,6 +43,7 @@ import EmergencySOSModal from "@/components/emergency/EmergencySOSModal";
 import { supabase } from "@/integrations/supabase/client";
 import { useQuery } from "@tanstack/react-query";
 import CarpoolSection from "@/components/carpool/CarpoolSection";
+import { useCarpools } from "@/hooks/useCarpools";
 import WeatherSummaryBanner from "@/components/weather/WeatherSummaryBanner";
 import OutingWeatherCard from "@/components/weather/OutingWeatherCard";
 import MarineMiniMap from "@/components/locations/MarineMiniMap";
@@ -74,6 +75,19 @@ const OutingDetail = () => {
   const unlockPOSS = useUnlockPOSS();
   const possGenerator = usePOSSGenerator();
   const { data: apneaLevels } = useApneaLevels();
+  const { data: carpools } = useCarpools(id ?? "");
+
+  // Set of user ids who already have a seat booked in a carpool for this outing
+  const bookedPassengerIds = new Set(
+    (carpools ?? []).flatMap((c) => (c.passengers ?? []).map((p) => p.passenger_id))
+  );
+  // Remaining (not yet booked) seats per driver, to stay consistent with the carpool widget
+  const remainingSeatsByDriver = new Map(
+    (carpools ?? []).map((c) => [
+      c.driver_id,
+      Math.max(0, (c.available_seats ?? 0) - (c.passengers?.length ?? 0)),
+    ])
+  );
   const addCoInstructor = useAddCoInstructor();
   const removeCoInstructor = useRemoveCoInstructor();
   const { data: allMembers } = useQuery({
@@ -787,11 +801,18 @@ const OutingDetail = () => {
                         )}
                         {reservation.carpool_option === "driver" && (
                           <Badge variant="secondary" className="text-xs gap-1">
-                            <Car className="h-3 w-3" /> {reservation.carpool_seats} places
+                            <Car className="h-3 w-3" />{" "}
+                            {(remainingSeatsByDriver.get(reservation.user_id) ?? reservation.carpool_seats)} dispo
                           </Badge>
                         )}
                         {reservation.carpool_option === "passenger" && (
-                          <Badge variant="outline" className="text-xs">Cherche covoit.</Badge>
+                          bookedPassengerIds.has(reservation.user_id) ? (
+                            <Badge variant="secondary" className="text-xs gap-1">
+                              <Car className="h-3 w-3" /> Inscrit covoit.
+                            </Badge>
+                          ) : (
+                            <Badge variant="outline" className="text-xs">Cherche covoit.</Badge>
+                          )
                         )}
                       </div>
                     </div>

--- a/src/pages/OutingView.tsx
+++ b/src/pages/OutingView.tsx
@@ -56,6 +56,7 @@ import { Anchor, Satellite } from "lucide-react";
 import { useApneaLevels, type ApneaLevel } from "@/hooks/useApneaLevels";
 
 import CarpoolSection from "@/components/carpool/CarpoolSection";
+import { useCarpools } from "@/hooks/useCarpools";
 import { FicheEvacuationGenerator } from "@/components/pdf/FicheEvacuationGenerator";
 
 /** Extract max depth from prerogatives string, e.g. "-40m / 80m dynamique" -> "-40m" */
@@ -96,6 +97,19 @@ const OutingView = () => {
   const cancelReservation = useCancelReservation();
   const updateCarpool = useUpdateReservationCarpool();
   const { data: apneaLevels } = useApneaLevels();
+  const { data: carpools } = useCarpools(id ?? "");
+
+  // Set of user ids who already have a seat booked in a carpool for this outing
+  const bookedPassengerIds = new Set(
+    (carpools ?? []).flatMap((c) => (c.passengers ?? []).map((p) => p.passenger_id))
+  );
+  // Remaining (not yet booked) seats per driver, to stay consistent with the carpool widget
+  const remainingSeatsByDriver = new Map(
+    (carpools ?? []).map((c) => [
+      c.driver_id,
+      Math.max(0, (c.available_seats ?? 0) - (c.passengers?.length ?? 0)),
+    ])
+  );
 
   const [carpoolOption, setCarpoolOption] = useState<CarpoolOption>("none");
   const [carpoolSeats, setCarpoolSeats] = useState(1);
@@ -649,11 +663,18 @@ const OutingView = () => {
                             )}
                             {reservation.carpool_option === "driver" && (
                               <Badge variant="secondary" className="text-xs gap-1">
-                                <Car className="h-3 w-3" /> {reservation.carpool_seats}
+                                <Car className="h-3 w-3" />{" "}
+                                {(remainingSeatsByDriver.get(reservation.user_id) ?? reservation.carpool_seats)} dispo
                               </Badge>
                             )}
                             {reservation.carpool_option === "passenger" && (
-                              <Badge variant="outline" className="text-xs">Cherche covoit.</Badge>
+                              bookedPassengerIds.has(reservation.user_id) ? (
+                                <Badge variant="secondary" className="text-xs gap-1">
+                                  <Car className="h-3 w-3" /> Inscrit covoit.
+                                </Badge>
+                              ) : (
+                                <Badge variant="outline" className="text-xs">Cherche covoit.</Badge>
+                              )
                             )}
                           </div>
                         </div>


### PR DESCRIPTION
## Contexte

Deux incohérences dans l'affichage des badges de covoiturage sur la fiche d'une sortie.

## Changements

### 1. Statut passager : "Cherche covoit." → "Inscrit covoit."
Dès qu'un passager a une place réservée dans un véhicule, son badge affiche désormais **"Inscrit covoit."** (icône voiture) au lieu de **"Cherche covoit."**.

L'état est dérivé en croisant les passagers réellement inscrits (`carpool_passengers`) — aucune mutation en base — donc le badge se met à jour automatiquement à l'inscription **et** à l'annulation.

### 2. Conducteur : places restantes au lieu du total proposé
Le badge du conducteur affichait le total de places proposées (`carpool_seats`), alors que le widget Covoiturage affiche les places **restantes**. Le badge affiche maintenant **"X dispo"** (places proposées − passagers inscrits), pour rester cohérent partout.

Appliqué sur les deux vues : `OutingView.tsx` et `OutingDetail.tsx`.

## Test
- `npm run build` ✅

https://claude.ai/code/session_01NHqNpvSFBz3DbUWCwQpWYG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHqNpvSFBz3DbUWCwQpWYG)_