### PR TITLE
feat: format uniforme des noms (Prénom NOM) à l'affichage

### DIFF
--- a/src/components/admin/ClubMembersDirectory.tsx
+++ b/src/components/admin/ClubMembersDirectory.tsx
@@ -87,7 +87,8 @@ import { supabase } from "@/integrations/supabase/client";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { cn } from "@/lib/utils";
-import { 
+import { formatFirstName, formatLastName } from "@/lib/formatName";
+import {
   cleanCsvCell,
   normalizePhone,
   parseCsvText,
@@ -498,8 +499,8 @@ const ClubMembersDirectory = () => {
 
         const reasons: string[] = [];
 
-        const firstName = cleanCsvCell((row as any).first_name) || "";
-        const lastName = cleanCsvCell((row as any).last_name) || "";
+        const firstName = formatFirstName(cleanCsvCell((row as any).first_name) || "");
+        const lastName = formatLastName(cleanCsvCell((row as any).last_name) || "");
         const email = (cleanCsvCell((row as any).email) || "").toLowerCase();
 
         if (!email) reasons.push("Email manquant");

--- a/src/components/admin/CreateOutingForm.tsx
+++ b/src/components/admin/CreateOutingForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { formatFullName } from "@/lib/formatName";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -818,7 +819,7 @@ const CreateOutingForm = ({ prefilledLocationId, prefilledLocationName, onClose 
                 <div className="flex flex-wrap gap-2">
                   {selectedCoInstructors.map((ci) => (
                     <span key={ci.id} className="flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                      {ci.first_name} {ci.last_name}
+                      {formatFullName(ci.first_name, ci.last_name)}
                       <button type="button" onClick={() => setSelectedCoInstructors((prev) => prev.filter((c) => c.id !== ci.id))}>
                         <X className="h-3 w-3" />
                       </button>
@@ -861,7 +862,7 @@ const CreateOutingForm = ({ prefilledLocationId, prefilledLocationName, onClose 
                             setCoInstructorPickerOpen(false);
                           }}
                         >
-                          {m.first_name} {m.last_name}
+                          {formatFullName(m.first_name, m.last_name)}
                         </button>
                       ))}
                   </div>

--- a/src/components/carpool/CarpoolCard.tsx
+++ b/src/components/carpool/CarpoolCard.tsx
@@ -1,4 +1,5 @@
 import { Clock, MapPin, ExternalLink, Users, Trash2, Edit2, MessageCircle, CheckCircle2 } from "lucide-react";
+import { formatFullName } from "@/lib/formatName";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -55,7 +56,7 @@ const CarpoolCard = ({
   const isBooked = !!userBookingId;
 
   const driverName = carpool.driver
-    ? `${carpool.driver.first_name} ${carpool.driver.last_name}`
+    ? formatFullName(carpool.driver.first_name, carpool.driver.last_name)
     : "Conducteur";
   const driverInitials = carpool.driver
     ? `${carpool.driver.first_name?.[0] ?? ""}${carpool.driver.last_name?.[0] ?? ""}`

--- a/src/components/carpool/CarpoolMapView.tsx
+++ b/src/components/carpool/CarpoolMapView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { formatFullName } from "@/lib/formatName";
 import { MapPin, Navigation, User, Clock } from "lucide-react";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
@@ -202,7 +203,7 @@ const CarpoolMapView = ({
       });
 
       const driverName = carpool.driver
-        ? `${carpool.driver.first_name} ${carpool.driver.last_name}`
+        ? formatFullName(carpool.driver.first_name, carpool.driver.last_name)
         : "Conducteur";
 
       const carMarker = L.marker([coords.lat, coords.lng], { icon: carIcon }).addTo(map);
@@ -275,7 +276,7 @@ const CarpoolMapView = ({
             </Avatar>
             <div>
               <p className="font-bold text-foreground">
-                {selectedCarpool.driver?.first_name} {selectedCarpool.driver?.last_name}
+                {formatFullName(selectedCarpool.driver?.first_name, selectedCarpool.driver?.last_name)}
               </p>
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Clock className="h-3 w-3" />

--- a/src/components/carpool/CarpoolSection.tsx
+++ b/src/components/carpool/CarpoolSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { formatFullName } from "@/lib/formatName";
 import { Car, Plus, AlertCircle, List, MapIcon, X } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -174,7 +175,7 @@ const CarpoolSection = ({ outingId, userReservation, isPast, destinationLat, des
             <AlertDescription>
               Vous avez réservé une place avec{" "}
               <strong>
-                {userBooking.carpool?.driver?.first_name} {userBooking.carpool?.driver?.last_name}
+                {formatFullName(userBooking.carpool?.driver?.first_name, userBooking.carpool?.driver?.last_name)}
               </strong>
               {" "}• Départ à {userBooking.carpool?.departure_time?.slice(0, 5)} depuis{" "}
               {userBooking.carpool?.meeting_point}

--- a/src/components/emergency/EmergencySOSModal.tsx
+++ b/src/components/emergency/EmergencySOSModal.tsx
@@ -1,4 +1,5 @@
 import { Phone, AlertTriangle, User } from "lucide-react";
+import { formatFullName } from "@/lib/formatName";
 import {
   Dialog,
   DialogContent,
@@ -80,7 +81,7 @@ const EmergencySOSModal = ({ isOpen, onClose, participants, outingTitle }: Emerg
                       </Avatar>
                       <div className="flex-1">
                         <p className="font-medium">
-                          {participant.first_name} {participant.last_name}
+                          {formatFullName(participant.first_name, participant.last_name)}
                         </p>
                         {participant.apnea_level && (
                           <Badge variant="outline" className="text-xs mt-1">

--- a/src/components/equipment/EquipmentDetailSheet.tsx
+++ b/src/components/equipment/EquipmentDetailSheet.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import { formatFullName } from "@/lib/formatName";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -155,7 +156,7 @@ export const EquipmentDetailSheet = ({ item, open, onOpenChange }: EquipmentDeta
                   <User className="h-4 w-4 text-muted-foreground shrink-0" />
                   <div>
                     <p className="text-muted-foreground text-xs">Détenteur</p>
-                    <p className="font-medium">{item.owner.first_name} {item.owner.last_name}</p>
+                    <p className="font-medium">{formatFullName(item.owner.first_name, item.owner.last_name)}</p>
                   </div>
                 </div>
               )}
@@ -269,7 +270,7 @@ export const EquipmentDetailSheet = ({ item, open, onOpenChange }: EquipmentDeta
                     ?.filter((e) => e.id !== user?.id)
                     .map((encadrant) => (
                       <SelectItem key={encadrant.id} value={encadrant.id}>
-                        {encadrant.first_name} {encadrant.last_name}
+                        {formatFullName(encadrant.first_name, encadrant.last_name)}
                       </SelectItem>
                     ))}
                 </SelectContent>

--- a/src/components/outings/EditHistoricalOutingDialog.tsx
+++ b/src/components/outings/EditHistoricalOutingDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
+import { formatFullName } from "@/lib/formatName";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -334,7 +335,7 @@ const EditHistoricalOutingDialog = ({ outing, open, onOpenChange }: Props) => {
                     </FormControl>
                     <SelectContent>
                       {encadrants?.map((e) => (
-                        <SelectItem key={e.id} value={e.id}>{e.first_name} {e.last_name}</SelectItem>
+                        <SelectItem key={e.id} value={e.id}>{formatFullName(e.first_name, e.last_name)}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
@@ -355,7 +356,7 @@ const EditHistoricalOutingDialog = ({ outing, open, onOpenChange }: Props) => {
                 <SelectContent>
                   <SelectItem value="none">Aucun</SelectItem>
                   {encadrants?.filter((e) => e.id !== organizerId).map((e) => (
-                    <SelectItem key={e.id} value={e.id}>{e.first_name} {e.last_name}</SelectItem>
+                    <SelectItem key={e.id} value={e.id}>{formatFullName(e.first_name, e.last_name)}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>

--- a/src/components/outings/HistoricalOutingForm.tsx
+++ b/src/components/outings/HistoricalOutingForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from "react";
+import { formatFullName } from "@/lib/formatName";
 import { useQuery } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -389,7 +390,7 @@ const HistoricalOutingForm = ({ open, onOpenChange }: HistoricalOutingFormProps)
                     <SelectContent>
                       {encadrants.map((m) => (
                         <SelectItem key={m.id} value={m.id}>
-                          {m.first_name} {m.last_name}
+                          {formatFullName(m.first_name, m.last_name)}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -415,7 +416,7 @@ const HistoricalOutingForm = ({ open, onOpenChange }: HistoricalOutingFormProps)
                     ?.filter((e) => e.id !== form.watch("organizer_id"))
                     .map((e) => (
                       <SelectItem key={e.id} value={e.id}>
-                        {e.first_name} {e.last_name}
+                        {formatFullName(e.first_name, e.last_name)}
                       </SelectItem>
                     ))}
                 </SelectContent>

--- a/src/components/outings/OutingCard.tsx
+++ b/src/components/outings/OutingCard.tsx
@@ -74,7 +74,7 @@ const OutingCard = ({ outing, carpoolInfo }: OutingCardProps) => {
   const currentParticipants = outing.confirmed_count ?? 0;
   const confirmedParticipantNames = (outing.reservations ?? [])
     .filter((r) => r.status === "confirmé" && r.profile)
-    .map((r) => `${r.profile!.first_name} ${r.profile!.last_name}`);
+    .map((r) => formatFullName(r.profile!.first_name, r.profile!.last_name));
   const isFull = currentParticipants >= outing.max_participants;
   const userReservation = outing.reservations?.find((r) => r.user_id === user?.id && r.status !== "annulé");
   const isRegistered = !!userReservation;

--- a/src/components/participants/ParticipantAvatar.tsx
+++ b/src/components/participants/ParticipantAvatar.tsx
@@ -1,4 +1,5 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { formatFullName } from "@/lib/formatName";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Shield, Star } from "lucide-react";
 
@@ -32,7 +33,7 @@ const ParticipantAvatar = ({
   size = "sm",
 }: ParticipantAvatarProps) => {
   const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
-  const fullName = `${firstName} ${lastName}`;
+  const fullName = formatFullName(firstName, lastName);
   const isEncadrant = memberStatus === "Encadrant";
 
   return (

--- a/src/components/pdf/pages/PDFPageBureau.tsx
+++ b/src/components/pdf/pages/PDFPageBureau.tsx
@@ -1,4 +1,5 @@
 import { PDFPageWrapper } from "../PDFPageWrapper";
+import { formatFullName } from "@/lib/formatName";
 import { PDFMember } from "@/hooks/usePDFReportData";
 
 interface PDFPageBureauProps {
@@ -108,7 +109,7 @@ export const PDFPageBureau = ({ members, pageNumber }: PDFPageBureauProps) => {
                   textAlign: "center",
                 }}
               >
-                {member.first_name} {member.last_name}
+                {formatFullName(member.first_name, member.last_name)}
               </h3>
 
               <span

--- a/src/components/sondages/SondagesAdmin.tsx
+++ b/src/components/sondages/SondagesAdmin.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import { formatFullName } from "@/lib/formatName";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
@@ -96,7 +97,7 @@ export default function SondagesAdmin() {
       const names = optionCounts.voters[opt.id] ?? [];
       names.forEach(name => rows.push([opt.label, name]));
     }
-    notVotedMembers.forEach(m => rows.push(["N'a pas voté", `${m.first_name} ${m.last_name}`]));
+    notVotedMembers.forEach(m => rows.push(["N'a pas voté", formatFullName(m.first_name, m.last_name)]));
     const csv = rows.map(r => r.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(",")).join("\n");
     const bom = new Uint8Array([0xEF, 0xBB, 0xBF]);
     const encoder = new TextEncoder();
@@ -212,7 +213,7 @@ export default function SondagesAdmin() {
     for (const v of votes) {
       for (const oid of v.selected_options) {
         counts[oid] = (counts[oid] ?? 0) + 1;
-        voters[oid] = [...(voters[oid] ?? []), v.member ? `${v.member.first_name} ${v.member.last_name}` : "?"];
+        voters[oid] = [...(voters[oid] ?? []), v.member ? formatFullName(v.member.first_name, v.member.last_name) : "?"];
       }
     }
     return { counts, voters };
@@ -466,7 +467,7 @@ export default function SondagesAdmin() {
                       <tr><td colSpan={selectedPoll.options.length + 2} className="px-4 py-6 text-center text-sm text-gray-400">Aucun résultat</td></tr>
                     )}
                     {filteredMembers.map(m => {
-                      const name = `${m.first_name} ${m.last_name}`;
+                      const name = formatFullName(m.first_name, m.last_name);
                       const isSaving = saving[m.id];
                       const rowPending = pending[m.id] ?? [];
                       return (

--- a/src/pages/Archives.tsx
+++ b/src/pages/Archives.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { formatFullName } from "@/lib/formatName";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -483,12 +484,12 @@ const Archives = () => {
                           {outing.location_details?.name || outing.location}
                           {outing.displayedOrganizer && (
                             <span className="ml-4">
-                              Encadrant: {outing.displayedOrganizer.first_name} {outing.displayedOrganizer.last_name}
+                              Encadrant: {formatFullName(outing.displayedOrganizer.first_name, outing.displayedOrganizer.last_name)}
                             </span>
                           )}
                           {outing.co_instructors?.length > 0 && (
                             <span className="ml-2">
-                              · Co-encadrant: {outing.co_instructors[0].profile.first_name} {outing.co_instructors[0].profile.last_name}
+                              · Co-encadrant: {formatFullName(outing.co_instructors[0].profile.first_name, outing.co_instructors[0].profile.last_name)}
                             </span>
                           )}
                         </div>
@@ -582,7 +583,7 @@ const Archives = () => {
                                             </Avatar>
                                             <div className="min-w-0 flex-1">
                                               <p className="text-sm font-medium text-foreground break-words leading-tight">
-                                                {member?.first_name} {member?.last_name}
+                                                {formatFullName(member?.first_name, member?.last_name)}
                                               </p>
                                               <Badge
                                                 variant={badgeVariant}
@@ -626,7 +627,7 @@ const Archives = () => {
                                             </Avatar>
                                             <div className="min-w-0 flex-1">
                                               <p className="text-sm font-medium text-foreground break-words leading-tight">
-                                                {profile?.first_name} {profile?.last_name}
+                                                {formatFullName(profile?.first_name, profile?.last_name)}
                                               </p>
                                               <Badge
                                                 variant={r.is_present ? "default" : "outline"}

--- a/src/pages/Equipment.tsx
+++ b/src/pages/Equipment.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef, useMemo } from "react";
+import { formatFullName } from "@/lib/formatName";
 import { useNavigate } from "react-router-dom";
 import { Loader2, Package, Plus, ArrowRightLeft, Trash2, Download, History, Users, Filter, Camera, Upload, Hash, BarChart3, List } from "lucide-react";
 import Layout from "@/components/layout/Layout";
@@ -573,7 +574,7 @@ const InventoryItemCard = ({ item, showActions = false }: { item: EquipmentInven
         </div>
         {item.owner && (
           <p className="text-xs text-muted-foreground">
-            Détenteur: {item.owner.first_name} {item.owner.last_name}
+            Détenteur: {formatFullName(item.owner.first_name, item.owner.last_name)}
           </p>
         )}
         {item.notes && (
@@ -609,7 +610,7 @@ const InventoryItemCard = ({ item, showActions = false }: { item: EquipmentInven
                         ?.filter((e) => e.id !== user?.id)
                         .map((encadrant) => (
                           <SelectItem key={encadrant.id} value={encadrant.id}>
-                            {encadrant.first_name} {encadrant.last_name}
+                            {formatFullName(encadrant.first_name, encadrant.last_name)}
                           </SelectItem>
                         ))}
                     </SelectContent>
@@ -695,7 +696,7 @@ const GlobalInventoryTab = () => {
       if (item.owner && !ownerMap.has(item.owner.id)) {
         ownerMap.set(item.owner.id, {
           id: item.owner.id,
-          name: `${item.owner.first_name} ${item.owner.last_name}`,
+          name: formatFullName(item.owner.first_name, item.owner.last_name),
           email: item.owner.email,
         });
       }
@@ -721,7 +722,7 @@ const GlobalInventoryTab = () => {
     const rows = inventory.map((item) => [
       item.unique_code || "",
       item.catalog?.name || "",
-      item.owner ? `${item.owner.first_name} ${item.owner.last_name}` : "",
+      item.owner ? formatFullName(item.owner.first_name, item.owner.last_name) : "",
       item.status,
       item.notes || "",
       format(new Date(item.acquired_at), "dd/MM/yyyy"),
@@ -889,14 +890,14 @@ const HistoryTab = () => {
                 <div className="text-sm">
                   {entry.action_type === "transfer" && entry.from_user && entry.to_user && (
                     <p>
-                      De <span className="font-medium">{entry.from_user.first_name} {entry.from_user.last_name}</span>
+                      De <span className="font-medium">{formatFullName(entry.from_user.first_name, entry.from_user.last_name)}</span>
                       {" → "}
-                      <span className="font-medium">{entry.to_user.first_name} {entry.to_user.last_name}</span>
+                      <span className="font-medium">{formatFullName(entry.to_user.first_name, entry.to_user.last_name)}</span>
                     </p>
                   )}
                   {entry.action_type === "acquisition" && entry.to_user && (
                     <p>
-                      Ajouté par <span className="font-medium">{entry.to_user.first_name} {entry.to_user.last_name}</span>
+                      Ajouté par <span className="font-medium">{formatFullName(entry.to_user.first_name, entry.to_user.last_name)}</span>
                     </p>
                   )}
                   {entry.action_type === "decommission" && (

--- a/src/pages/MemberManagement.tsx
+++ b/src/pages/MemberManagement.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { formatFullName } from "@/lib/formatName";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Loader2, Users, Search, Shield, User, Trash2, AlertTriangle } from "lucide-react";
@@ -240,7 +241,7 @@ const MemberManagement = () => {
                           </Avatar>
                           <div>
                             <p className="font-semibold text-foreground">
-                              {profile.first_name} {profile.last_name}
+                              {formatFullName(profile.first_name, profile.last_name)}
                             </p>
                             <p className="text-sm text-muted-foreground">{profile.email}</p>
                           </div>
@@ -344,7 +345,7 @@ const MemberManagement = () => {
                                 </AlertDialogTitle>
                                 <AlertDialogDescription>
                                   Cette action est irréversible. Le profil de{" "}
-                                  <strong>{profile.first_name} {profile.last_name}</strong>{" "}
+                                  <strong>{formatFullName(profile.first_name, profile.last_name)}</strong>{" "}
                                   et toutes ses réservations seront supprimés.
                                 </AlertDialogDescription>
                               </AlertDialogHeader>

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -775,7 +775,7 @@ const OutingDetail = () => {
                     <div>
                       <div className="flex items-center gap-2">
                         <p className="font-medium text-foreground">
-                          {profile?.first_name} {profile?.last_name}
+                          {formatFullName(profile?.first_name, profile?.last_name)}
                         </p>
                         {isOrg && (
                           <Badge className="bg-amber-500 text-white text-[10px] px-1.5 py-0">Organisateur</Badge>
@@ -894,7 +894,7 @@ const OutingDetail = () => {
                           <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-amber-100 text-xs font-semibold text-amber-700">
                             {index + 1}
                           </span>
-                          {profile?.first_name} {profile?.last_name}
+                          {formatFullName(profile?.first_name, profile?.last_name)}
                         </div>
                       );
                     })}
@@ -920,7 +920,7 @@ const OutingDetail = () => {
                           )}
                         >
                           <XCircle className="h-4 w-4" />
-                          {profile?.first_name} {profile?.last_name}
+                          {formatFullName(profile?.first_name, profile?.last_name)}
                           {isLastMinute && <Badge variant="destructive" className="text-xs">-24h</Badge>}
                         </div>
                       );

--- a/src/pages/OutingView.tsx
+++ b/src/pages/OutingView.tsx
@@ -1,4 +1,5 @@
 import { useParams, useNavigate, useLocation, Link } from "react-router-dom";
+import { formatFullName } from "@/lib/formatName";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import {
@@ -640,7 +641,7 @@ const OutingView = () => {
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2">
                             <p className="font-medium text-foreground truncate">
-                              {profile?.first_name} {profile?.last_name}
+                              {formatFullName(profile?.first_name, profile?.last_name)}
                             </p>
                             {isOrg && (
                               <Badge className="bg-amber-500 text-white text-[10px] px-1.5 py-0">Organisateur</Badge>

--- a/src/pages/Reservations.tsx
+++ b/src/pages/Reservations.tsx
@@ -1,3 +1,4 @@
+import { formatFullName } from "@/lib/formatName";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { Calendar, MapPin, Loader2, Waves, Users, ChevronRight, Clock } from "lucide-react";
@@ -218,7 +219,7 @@ const Reservations = () => {
                                             >
                                               {index + 1}
                                             </span>
-                                            {p.first_name} {p.last_name}
+                                            {formatFullName(p.first_name, p.last_name)}
                                             {isMe && (
                                               <span className="ml-1 text-xs font-medium text-amber-600">
                                                 (vous)

--- a/src/pages/SondageVote.tsx
+++ b/src/pages/SondageVote.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { formatFullName } from "@/lib/formatName";
 import { useParams, useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
@@ -144,7 +145,7 @@ export default function SondageVote() {
         <div className="w-full max-w-sm">
           <div className="mb-6">
             <h1 className="text-xl font-bold">{poll?.title}</h1>
-            <p className="text-sm text-gray-400 mt-1">Bonjour {member?.first_name} {member?.last_name}</p>
+            <p className="text-sm text-gray-400 mt-1">Bonjour {formatFullName(member?.first_name, member?.last_name)}</p>
           </div>
 
           <p className="text-sm text-gray-500 mb-4">

--- a/src/pages/Souvenirs.tsx
+++ b/src/pages/Souvenirs.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { formatFullName } from "@/lib/formatName";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { useQuery } from "@tanstack/react-query";
@@ -296,7 +297,7 @@ const Souvenirs = () => {
                               </div>
                               <div>
                                 <p className="text-sm font-medium text-foreground">
-                                  {p.first_name} {p.last_name}
+                                  {formatFullName(p.first_name, p.last_name)}
                                 </p>
                                 {isEncadrant && (
                                   <Badge variant="outline" className="text-xs text-amber-600 border-amber-300">Encadrant</Badge>


### PR DESCRIPTION
## Problème

Le formatage des noms était incohérent à l'affichage (ex. "Xavier Remy", "Farid Nadji", "Virginie POITEVIN" mélangés) car les données brutes en base ont des casses variées.

## Solution (affichage, non destructif)

Application du helper existant `formatFullName` (et `formatFirstName`/`formatLastName`) partout où les noms sont **affichés**, pour garantir la règle : **Prénom** (1ère lettre majuscule) + **NOM** (majuscules).

### Surfaces traitées (~20 fichiers)
Cartes sorties + popover inscrits, détails sortie, covoiturage (cartes/carte/section), matériel (détenteur, historique, détail), sondages (table + export), modal urgence SOS, PDF Bureau, listes/pickers encadrants, avatars participants, etc.

### Import CSV
Les prénoms/noms sont aussi normalisés à l'import des adhérents, pour ne pas réintroduire d'incohérences au prochain import.

### Non touché
- Aucune donnée existante mutée (formatage purement à l'affichage)
- Logiques de recherche/filtre/tri intactes
- Attributs `alt` d'images et clés `value` de Select intacts

## Test
- `npm run build` ✅

https://claude.ai/code/session_01NHqNpvSFBz3DbUWCwQpWYG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHqNpvSFBz3DbUWCwQpWYG)_