### PR TITLE
feat: bouton "Ajouter au calendrier" (Google / Outlook / ICS)

### DIFF
--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,0 +1,93 @@
+/**
+ * Helpers to add an outing to an external calendar (Google, Outlook, ICS).
+ */
+
+export interface CalendarEvent {
+  title: string;
+  /** ISO start date/time */
+  start: string | Date;
+  /** ISO end date/time. Defaults to start + 3h if absent. */
+  end?: string | Date | null;
+  description?: string | null;
+  location?: string | null;
+}
+
+const DEFAULT_DURATION_MS = 3 * 60 * 60 * 1000; // 3h
+
+const toDate = (value: string | Date): Date =>
+  value instanceof Date ? value : new Date(value);
+
+const resolveDates = (event: CalendarEvent): { start: Date; end: Date } => {
+  const start = toDate(event.start);
+  const end = event.end ? toDate(event.end) : new Date(start.getTime() + DEFAULT_DURATION_MS);
+  return { start, end };
+};
+
+/** Format a date to the UTC compact form used by calendar URLs/ICS: YYYYMMDDTHHMMSSZ */
+const toUTCStamp = (date: Date): string =>
+  date.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}/, "");
+
+/** Google Calendar "create event" URL */
+export const buildGoogleCalendarUrl = (event: CalendarEvent): string => {
+  const { start, end } = resolveDates(event);
+  const params = new URLSearchParams({
+    action: "TEMPLATE",
+    text: event.title,
+    dates: `${toUTCStamp(start)}/${toUTCStamp(end)}`,
+  });
+  if (event.description) params.set("details", event.description);
+  if (event.location) params.set("location", event.location);
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+};
+
+/** Outlook Web "compose event" URL */
+export const buildOutlookCalendarUrl = (event: CalendarEvent): string => {
+  const { start, end } = resolveDates(event);
+  const params = new URLSearchParams({
+    path: "/calendar/action/compose",
+    rru: "addevent",
+    subject: event.title,
+    startdt: start.toISOString(),
+    enddt: end.toISOString(),
+  });
+  if (event.description) params.set("body", event.description);
+  if (event.location) params.set("location", event.location);
+  return `https://outlook.live.com/calendar/0/deeplink/compose?${params.toString()}`;
+};
+
+/** Escape special characters per the ICS spec */
+const escapeICS = (value: string): string =>
+  value.replace(/\\/g, "\\\\").replace(/;/g, "\\;").replace(/,/g, "\\,").replace(/\n/g, "\\n");
+
+/** Build the content of an .ics file for the event */
+export const buildICS = (event: CalendarEvent): string => {
+  const { start, end } = resolveDates(event);
+  const uid = `${toUTCStamp(start)}-${Math.random().toString(36).slice(2)}@deep-dive-planner`;
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Deep Dive Planner//FR",
+    "CALSCALE:GREGORIAN",
+    "BEGIN:VEVENT",
+    `UID:${uid}`,
+    `DTSTAMP:${toUTCStamp(new Date())}`,
+    `DTSTART:${toUTCStamp(start)}`,
+    `DTEND:${toUTCStamp(end)}`,
+    `SUMMARY:${escapeICS(event.title)}`,
+  ];
+  if (event.description) lines.push(`DESCRIPTION:${escapeICS(event.description)}`);
+  if (event.location) lines.push(`LOCATION:${escapeICS(event.location)}`);
+  lines.push("END:VEVENT", "END:VCALENDAR");
+  return lines.join("\r\n");
+};
+
+/** Trigger a download of the event as an .ics file */
+export const downloadICS = (event: CalendarEvent, filename = "sortie.ics"): void => {
+  const blob = new Blob([buildICS(event)], { type: "text/calendar;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+};

--- a/src/pages/Reservations.tsx
+++ b/src/pages/Reservations.tsx
@@ -1,11 +1,23 @@
 import { formatFullName } from "@/lib/formatName";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
-import { Calendar, MapPin, Loader2, Waves, Users, ChevronRight, Clock } from "lucide-react";
+import { Calendar, MapPin, Loader2, Waves, Users, ChevronRight, Clock, CalendarPlus } from "lucide-react";
 import Layout from "@/components/layout/Layout";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  buildGoogleCalendarUrl,
+  buildOutlookCalendarUrl,
+  downloadICS,
+  type CalendarEvent,
+} from "@/lib/calendar";
 import { useMyReservations, useCancelReservation } from "@/hooks/useOutings";
 import { useAuth } from "@/contexts/AuthContext";
 import { Navigate, useNavigate } from "react-router-dom";
@@ -235,10 +247,67 @@ const Reservations = () => {
                             );
                           })()}
 
+                          {(() => {
+                            const o = reservation.outing;
+                            if (!o?.date_time) return null;
+                            const calendarEvent: CalendarEvent = {
+                              title: o.title,
+                              start: o.date_time,
+                              end: o.end_date,
+                              description: o.description,
+                              location: o.location_details?.name || o.location,
+                            };
+                            return (
+                              <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className="w-full mt-4"
+                                    onClick={(e) => e.stopPropagation()}
+                                  >
+                                    <CalendarPlus className="h-4 w-4 mr-2" />
+                                    Ajouter au calendrier
+                                  </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent
+                                  align="center"
+                                  className="w-[var(--radix-dropdown-menu-trigger-width)]"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  <DropdownMenuItem
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      window.open(buildGoogleCalendarUrl(calendarEvent), "_blank", "noopener,noreferrer");
+                                    }}
+                                  >
+                                    Google Agenda
+                                  </DropdownMenuItem>
+                                  <DropdownMenuItem
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      window.open(buildOutlookCalendarUrl(calendarEvent), "_blank", "noopener,noreferrer");
+                                    }}
+                                  >
+                                    Outlook
+                                  </DropdownMenuItem>
+                                  <DropdownMenuItem
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      downloadICS(calendarEvent, `${o.title?.replace(/[^a-z0-9]+/gi, "-").toLowerCase() || "sortie"}.ics`);
+                                    }}
+                                  >
+                                    Apple / Autre (.ics)
+                                  </DropdownMenuItem>
+                                </DropdownMenuContent>
+                              </DropdownMenu>
+                            );
+                          })()}
+
                           <Button
                             variant="outline"
                             size="sm"
-                            className="w-full mt-4"
+                            className="w-full mt-2"
                             onClick={(e) => {
                               e.stopPropagation();
                               cancelReservation.mutate(reservation.outing_id);


### PR DESCRIPTION
## Fonctionnalité

Sur la page **Mes Réservations**, chaque sortie à venir dispose désormais d'un bouton **"Ajouter au calendrier"** (au-dessus de "Annuler ma réservation").

Un menu propose 3 options :
- **Google Agenda** — ouvre la page de création d'événement pré-remplie
- **Outlook** — idem côté Outlook Web
- **Apple / Autre (.ics)** — télécharge un fichier `.ics` compatible Apple Calendar, Outlook desktop, etc.

L'événement reprend : titre, date de début, date de fin (ou +3h par défaut), description et lieu.

## Implémentation
- Nouveau helper `src/lib/calendar.ts` : `buildGoogleCalendarUrl`, `buildOutlookCalendarUrl`, `buildICS`, `downloadICS`
- `stopPropagation` sur le menu pour ne pas déclencher la navigation vers le détail de la sortie au clic

## Test
- `npm run build` ✅

https://claude.ai/code/session_01NHqNpvSFBz3DbUWCwQpWYG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHqNpvSFBz3DbUWCwQpWYG)_