### PR TITLE
fix: fiche d'évacuation réservée aux encadrants + mise en forme PDF

### DIFF
--- a/src/components/pdf/FicheEvacuationGenerator.tsx
+++ b/src/components/pdf/FicheEvacuationGenerator.tsx
@@ -2,11 +2,17 @@ import { useState, useRef } from "react";
 import { Download, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import html2canvas from "html2canvas";
 import jsPDF from "jspdf";
 import { PDFPageEvacuationApnee } from "./pages/PDFPageEvacuationApnee";
 
-export const FicheEvacuationGenerator = () => {
+interface FicheEvacuationGeneratorProps {
+  /** Compact button for toolbars (size sm, no full width) */
+  compact?: boolean;
+}
+
+export const FicheEvacuationGenerator = ({ compact = false }: FicheEvacuationGeneratorProps) => {
   const [isGenerating, setIsGenerating] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -51,14 +57,21 @@ export const FicheEvacuationGenerator = () => {
     <>
       <Button
         variant="outline"
-        className="w-full gap-2 border-destructive/40 text-destructive hover:bg-destructive/5"
+        size={compact ? "sm" : "default"}
+        className={cn(
+          "gap-2 border-destructive/40 text-destructive hover:bg-destructive/5",
+          !compact && "w-full"
+        )}
         onClick={generatePDF}
         disabled={isGenerating}
       >
         {isGenerating ? (
           <><Loader2 className="h-4 w-4 animate-spin" />Génération...</>
         ) : (
-          <><Download className="h-4 w-4" />Fiche d'évacuation de plongeur (Annexe III-19)</>
+          <>
+            <Download className="h-4 w-4" />
+            {compact ? "Fiche d'évacuation" : "Fiche d'évacuation de plongeur (Annexe III-19)"}
+          </>
         )}
       </Button>
 

--- a/src/components/pdf/pages/PDFPageEvacuationApnee.tsx
+++ b/src/components/pdf/pages/PDFPageEvacuationApnee.tsx
@@ -3,40 +3,130 @@ import logoTeamOxygen from "@/assets/logo-team-oxygen.webp";
 const LINE_COLOR = "#1a1a1a";
 const BORDER = `1px solid ${LINE_COLOR}`;
 const SECTION_BG = "#1e3a5f";
+const LINE_HEIGHT = "13px";
 
-const Line = ({ label, width = "100%", ml = 4 }: { label: string; width?: string; ml?: number }) => (
-  <div style={{ display: "flex", alignItems: "baseline", gap: "4px", flex: width === "100%" ? 1 : undefined, width: width !== "100%" ? width : undefined }}>
-    <span style={{ fontSize: "10px", whiteSpace: "nowrap" }}>{label}</span>
-    <div style={{ flex: 1, borderBottom: BORDER, marginLeft: `${ml}px`, minWidth: "20px" }} />
+/**
+ * Label + fill-in line, bottom-aligned so the rule sits exactly at the text
+ * baseline (html2canvas renders empty flex divs poorly with baseline alignment).
+ * Optional `value` is printed just above the rule.
+ */
+const Line = ({
+  label,
+  width = "100%",
+  value,
+}: {
+  label: string;
+  width?: string;
+  value?: string;
+}) => (
+  <div
+    style={{
+      display: "flex",
+      alignItems: "flex-end",
+      gap: "6px",
+      flex: width === "100%" ? 1 : undefined,
+      width: width !== "100%" ? width : undefined,
+    }}
+  >
+    <span style={{ fontSize: "10px", whiteSpace: "nowrap", lineHeight: LINE_HEIGHT }}>{label}</span>
+    <div
+      style={{
+        flex: 1,
+        borderBottom: BORDER,
+        minWidth: "20px",
+        height: LINE_HEIGHT,
+        display: "flex",
+        alignItems: "flex-end",
+      }}
+    >
+      {value && (
+        <span
+          style={{
+            fontSize: "10px",
+            lineHeight: LINE_HEIGHT,
+            paddingLeft: "4px",
+            paddingBottom: "1px",
+            color: "#555",
+            fontStyle: "italic",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {value}
+        </span>
+      )}
+    </div>
+  </div>
+);
+
+/** Row of Line components, bottom-aligned, with optional trailing unit label */
+const LineRow = ({
+  children,
+  unit,
+  mb = 6,
+}: {
+  children: React.ReactNode;
+  unit?: string;
+  mb?: number;
+}) => (
+  <div style={{ display: "flex", alignItems: "flex-end", gap: "12px", marginBottom: `${mb}px` }}>
+    {children}
+    {unit && (
+      <span style={{ fontSize: "10px", lineHeight: LINE_HEIGHT, whiteSpace: "nowrap" }}>{unit}</span>
+    )}
   </div>
 );
 
 const CheckBox = ({ label, checked = false }: { label: string; checked?: boolean }) => (
   <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
-    <div style={{
-      width: "12px", height: "12px", border: BORDER, flexShrink: 0,
-      backgroundColor: checked ? LINE_COLOR : "white",
-      display: "flex", alignItems: "center", justifyContent: "center",
-    }}>
+    <div
+      style={{
+        width: "11px",
+        height: "11px",
+        border: BORDER,
+        flexShrink: 0,
+        backgroundColor: checked ? LINE_COLOR : "white",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
       {checked && <span style={{ color: "white", fontSize: "9px", lineHeight: 1 }}>✓</span>}
     </div>
-    <span style={{ fontSize: "10px" }}>{label}</span>
+    <span style={{ fontSize: "10px", lineHeight: "12px" }}>{label}</span>
   </div>
 );
 
 const SectionHeader = ({ title }: { title: string }) => (
-  <div style={{
-    backgroundColor: SECTION_BG,
-    color: "white",
-    padding: "4px 10px",
-    fontSize: "10px",
-    fontWeight: "700",
-    textAlign: "center",
-    letterSpacing: "0.5px",
-    textTransform: "uppercase",
-    marginBottom: "6px",
-  }}>
+  <div
+    style={{
+      backgroundColor: SECTION_BG,
+      color: "white",
+      padding: "4px 10px",
+      fontSize: "10px",
+      fontWeight: "700",
+      textAlign: "center",
+      letterSpacing: "0.5px",
+      textTransform: "uppercase",
+      marginBottom: "8px",
+    }}
+  >
     {title}
+  </div>
+);
+
+/** Ruled row with a fixed-width "Heure" cell on the right */
+const TimedRow = () => (
+  <div
+    style={{
+      display: "flex",
+      alignItems: "stretch",
+      borderBottom: "1px solid #aaa",
+      marginBottom: "9px",
+      height: "14px",
+    }}
+  >
+    <div style={{ flex: 1 }} />
+    <div style={{ width: "52px", borderLeft: "1px solid #aaa" }} />
   </div>
 );
 
@@ -81,25 +171,25 @@ export const PDFPageEvacuationApnee = () => {
         </div>
       </div>
 
-      <div style={{ borderTop: `2px solid ${SECTION_BG}`, marginBottom: "10px" }} />
+      <div style={{ borderTop: `2px solid ${SECTION_BG}`, marginBottom: "12px" }} />
 
       {/* ── Identification ── */}
-      <div style={{ marginBottom: "10px" }}>
-        <div style={{ display: "flex", gap: "12px", marginBottom: "5px" }}>
+      <div style={{ marginBottom: "12px" }}>
+        <LineRow mb={7}>
           <Line label="NOM" />
           <Line label="PRÉNOM" />
           <Line label="Date de naissance" width="200px" />
-        </div>
-        <div style={{ display: "flex", gap: "12px", marginBottom: "5px" }}>
-          <Line label="Date" width="120px" />
+        </LineRow>
+        <LineRow mb={7}>
+          <Line label="Date" width="160px" />
           <Line label="Tél club ou directeur de plongée" />
-        </div>
-        <div style={{ display: "flex", alignItems: "baseline", gap: "4px" }}>
-          <span style={{ fontSize: "10px", whiteSpace: "nowrap" }}>Nom et adresse de l'établissement</span>
-          <div style={{ flex: 1, borderBottom: BORDER, marginLeft: "4px", fontSize: "10px", paddingLeft: "4px", color: "#555", fontStyle: "italic" }}>
-            Team Oxygen — Association d'apnée, Martigues / Marseille
-          </div>
-        </div>
+        </LineRow>
+        <LineRow mb={0}>
+          <Line
+            label="Nom et adresse de l'établissement"
+            value="Team Oxygen — Association d'apnée, Martigues / Marseille"
+          />
+        </LineRow>
       </div>
 
       {/* ── Caractéristiques ── */}
@@ -108,42 +198,36 @@ export const PDFPageEvacuationApnee = () => {
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0" }}>
           {/* Left */}
           <div style={{ padding: "0 10px 8px", borderRight: BORDER }}>
-            <div style={{ display: "flex", gap: "10px", marginBottom: "6px" }}>
+            <LineRow mb={7}>
               <Line label="Lieu" />
-            </div>
-            <div style={{ display: "flex", gap: "12px", marginBottom: "6px" }}>
-              <Line label="Profondeur maximale" width="200px" />
-              <span style={{ fontSize: "10px", alignSelf: "flex-end" }}>mètres</span>
-            </div>
-            <div style={{ display: "flex", gap: "12px", marginBottom: "6px" }}>
-              <Line label="Durée totale" width="190px" />
-              <span style={{ fontSize: "10px", alignSelf: "flex-end" }}>minutes</span>
-            </div>
-            <div style={{ display: "flex", gap: "12px", marginBottom: "8px" }}>
+            </LineRow>
+            <LineRow mb={7} unit="mètres">
+              <Line label="Profondeur maximale" width="220px" />
+            </LineRow>
+            <LineRow mb={7} unit="minutes">
+              <Line label="Durée totale" width="220px" />
+            </LineRow>
+            <LineRow mb={9}>
               <Line label="Heure de sortie de l'eau" />
-            </div>
+            </LineRow>
             <div style={{ marginBottom: "4px" }}>
-              <span style={{ fontSize: "10px" }}>Incidents :</span>
+              <span style={{ fontSize: "10px", lineHeight: LINE_HEIGHT }}>Incidents :</span>
               {[1, 2, 3].map((i) => (
-                <div key={i} style={{ borderBottom: "1px solid #aaa", marginTop: "10px" }} />
+                <div key={i} style={{ borderBottom: "1px solid #aaa", marginTop: "13px" }} />
               ))}
             </div>
           </div>
 
           {/* Right — signes observés */}
           <div style={{ padding: "0 10px 8px" }}>
-            <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "4px" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "5px" }}>
               <span style={{ fontSize: "10px", fontWeight: "700" }}>Signes observés</span>
-              <span style={{ fontSize: "10px", fontWeight: "700" }}>Heure</span>
+              <span style={{ fontSize: "10px", fontWeight: "700", width: "52px", paddingLeft: "6px", boxSizing: "border-box" }}>
+                Heure
+              </span>
             </div>
             {Array.from({ length: 9 }).map((_, i) => (
-              <div key={i} style={{
-                display: "flex", justifyContent: "space-between", alignItems: "flex-end",
-                borderBottom: "1px solid #aaa", marginBottom: "8px", paddingBottom: "1px",
-              }}>
-                <div style={{ flex: 1 }} />
-                <div style={{ width: "50px", borderLeft: "1px solid #aaa", paddingLeft: "6px", height: "14px" }} />
-              </div>
+              <TimedRow key={i} />
             ))}
           </div>
         </div>
@@ -152,7 +236,7 @@ export const PDFPageEvacuationApnee = () => {
       {/* ── Premiers soins ── */}
       <div style={{ border: BORDER, marginBottom: "10px" }}>
         <SectionHeader title="Premiers soins" />
-        <div style={{ padding: "6px 14px 10px", display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: "8px" }}>
+        <div style={{ padding: "2px 14px 10px", display: "grid", gridTemplateColumns: "1fr 1fr 1fr", rowGap: "8px", columnGap: "8px" }}>
           <CheckBox label="Position latérale de sécurité" />
           <CheckBox label="Massage cardiaque externe" />
           <CheckBox label="Bouche à bouche" />
@@ -165,53 +249,48 @@ export const PDFPageEvacuationApnee = () => {
       {/* ── Intervention médicale ── */}
       <div style={{ border: BORDER, marginBottom: "10px" }}>
         <SectionHeader title="Intervention médicale" />
-        <div style={{ padding: "6px 10px 10px" }}>
-          <div style={{ display: "flex", gap: "12px", marginBottom: "6px" }}>
+        <div style={{ padding: "2px 10px 10px" }}>
+          <LineRow mb={7}>
             <Line label="Nom du médecin" />
             <Line label="Tél" width="160px" />
-          </div>
-          <div style={{ display: "flex", gap: "12px", marginBottom: "6px" }}>
+          </LineRow>
+          <LineRow mb={9}>
             <Line label="Heure de prise en charge" width="220px" />
             <Line label="Lieu" />
-          </div>
+          </LineRow>
           <div style={{ marginBottom: "4px" }}>
-            <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "4px" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "5px" }}>
               <span style={{ fontSize: "10px", fontWeight: "600" }}>Examen clinique et diagnostic évoqué</span>
-              <span style={{ fontSize: "10px", fontWeight: "600" }}>Heure</span>
+              <span style={{ fontSize: "10px", fontWeight: "600", width: "52px", paddingLeft: "6px", boxSizing: "border-box" }}>
+                Heure
+              </span>
             </div>
             {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} style={{
-                display: "flex", justifyContent: "space-between", alignItems: "flex-end",
-                borderBottom: "1px solid #aaa", marginBottom: "8px",
-              }}>
-                <div style={{ flex: 1 }} />
-                <div style={{ width: "50px", borderLeft: "1px solid #aaa", paddingLeft: "6px", height: "14px" }} />
-              </div>
+              <TimedRow key={i} />
             ))}
           </div>
-          <div style={{ display: "flex", alignItems: "baseline", gap: "4px", marginTop: "4px" }}>
-            <span style={{ fontSize: "10px" }}>Traitement :</span>
-            <div style={{ flex: 1, borderBottom: BORDER }} />
-          </div>
-          <div style={{ borderBottom: BORDER, marginTop: "10px" }} />
+          <LineRow mb={0}>
+            <Line label="Traitement :" />
+          </LineRow>
+          <div style={{ borderBottom: BORDER, marginTop: "13px" }} />
         </div>
       </div>
 
       {/* ── Évacuation primaire ── */}
       <div style={{ border: BORDER }}>
         <SectionHeader title="Évacuation primaire" />
-        <div style={{ padding: "6px 10px 10px" }}>
-          <div style={{ display: "flex", gap: "12px", marginBottom: "6px" }}>
+        <div style={{ padding: "2px 10px 10px" }}>
+          <LineRow mb={8}>
             <Line label="Service d'accueil" />
-            <Line label="Moyen(s)" width="140px" />
-            <Line label="Durée totale" width="120px" />
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "14px" }}>
-            <span style={{ fontSize: "10px", whiteSpace: "nowrap" }}>Médicalisation</span>
+            <Line label="Moyen(s)" width="160px" />
+            <Line label="Durée totale" width="140px" />
+          </LineRow>
+          <div style={{ display: "flex", alignItems: "flex-end", gap: "14px" }}>
+            <span style={{ fontSize: "10px", whiteSpace: "nowrap", lineHeight: "12px" }}>Médicalisation</span>
             <CheckBox label="oui" />
             <CheckBox label="non" />
             <Line label="Médecin convoyeur" />
-            <Line label="Tél" width="130px" />
+            <Line label="Tél" width="140px" />
           </div>
         </div>
       </div>

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -40,6 +40,7 @@ import { usePOSSGenerator } from "@/hooks/usePOSSGenerator";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import EmergencySOSModal from "@/components/emergency/EmergencySOSModal";
+import { FicheEvacuationGenerator } from "@/components/pdf/FicheEvacuationGenerator";
 import { supabase } from "@/integrations/supabase/client";
 import { useQuery } from "@tanstack/react-query";
 import CarpoolSection from "@/components/carpool/CarpoolSection";
@@ -380,6 +381,8 @@ const OutingDetail = () => {
                 <Download className="h-4 w-4" />
                 Fiche Sécurité
               </Button>
+              {/* Fiche évacuation - encadrants uniquement */}
+              {canManageOuting && <FicheEvacuationGenerator compact />}
               {!isPast && canCancelOuting && (
                 <EditOutingDialog outing={outing} />
               )}

--- a/src/pages/OutingView.tsx
+++ b/src/pages/OutingView.tsx
@@ -58,7 +58,6 @@ import { useApneaLevels, type ApneaLevel } from "@/hooks/useApneaLevels";
 
 import CarpoolSection from "@/components/carpool/CarpoolSection";
 import { useCarpools } from "@/hooks/useCarpools";
-import { FicheEvacuationGenerator } from "@/components/pdf/FicheEvacuationGenerator";
 
 /** Extract max depth from prerogatives string, e.g. "-40m / 80m dynamique" -> "-40m" */
 const extractDepth = (prerogatives: string | null): string | null => {
@@ -586,11 +585,6 @@ const OutingView = () => {
                 <Download className="h-4 w-4" />
                 Télécharger la Fiche Sécurité Apnée
               </Button>
-
-              {/* Fiche évacuation - encadrants only */}
-              {(user.id === organizerId || isCoInstructor) && (
-                <FicheEvacuationGenerator />
-              )}
             </CardContent>
           </Card>
 


### PR DESCRIPTION
## Changements

### 1. Fiche d'évacuation réservée aux encadrants (Mes Sorties)
Le bouton **"Fiche d'évacuation de plongeur (Annexe III-19)"** est retiré de la vue participant (`/outing/:id`, accessible depuis Mes Réservations) et déplacé dans la vue gestion (`/outing/:id/manage`, accessible depuis Mes Sorties), à côté du bouton "Fiche Sécurité".

Visible uniquement pour **organisateur / co-encadrant / admin** (`canManageOuting`). Le composant accepte une prop `compact` pour s'intégrer à la barre d'outils (taille sm, libellé court "Fiche d'évacuation").

### 2. Mise en forme du PDF retravaillée
- **Lignes de saisie alignées sur la base du texte** : remplacement de l'alignement `baseline` (mal rendu par html2canvas sur des divs vides — les lignes "flottaient" au-dessus des libellés) par `flex-end` + hauteur fixe
- **Texte pré-rempli de l'établissement** posé correctement au-dessus de la ligne (plus d'effet "barré")
- **Unités "mètres" / "minutes" alignées verticalement** (largeurs de lignes identiques)
- **Colonne "Heure"** des tableaux (Signes observés, Examen clinique) : en-tête aligné avec ses cellules (largeur fixe commune)
- Espacements entre lignes/sections uniformisés

## Test
- `npm run build` ✅

https://claude.ai/code/session_01NHqNpvSFBz3DbUWCwQpWYG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHqNpvSFBz3DbUWCwQpWYG)_