### PR TITLE
chore: skill verify-pdf — vérification visuelle des pages PDF

### DIFF
--- a/.claude/skills/verify-pdf/SKILL.md
+++ b/.claude/skills/verify-pdf/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: verify-pdf
+description: Rendu visuel exact d'une page PDF (pipeline React + html2canvas) pour vérifier la mise en forme AVANT de pousser. Utiliser à chaque modification d'un composant de src/components/pdf/pages/.
+---
+
+# Vérifier le rendu d'une page PDF
+
+Les PDF de l'app sont générés en capturant un composant React avec html2canvas
+(jsPDF assemble ensuite l'image). html2canvas a des écarts de rendu connus par
+rapport au navigateur (alignements flex `center`/`baseline` non fiables,
+notamment). **Une page PDF modifiée doit donc être vérifiée via ce skill — pas
+seulement via `npm run build`** : la capture produite contient les pixels
+exacts du futur PDF.
+
+## Usage
+
+```bash
+node .claude/skills/verify-pdf/render-pdf-page.mjs <NomComposant> [options]
+```
+
+Exemple :
+
+```bash
+node .claude/skills/verify-pdf/render-pdf-page.mjs PDFPageEvacuationApnee
+# → /tmp/pdf-verify-PDFPageEvacuationApnee.png
+```
+
+Options :
+- `--props <fichier.json>` : props à passer au composant (JSON)
+- `--width <px>` / `--height <px>` : dimensions de la page (défaut 794×1123, A4 portrait à 96dpi ; A4 paysage = 1123×794)
+- `--out <chemin.png>` : chemin de sortie de la capture
+
+Ensuite **lire le PNG produit** (outil Read) et inspecter : alignements des
+lignes/cases/libellés, débordements, chevauchements texte/règles.
+
+## Composants
+
+Les pages sont dans `src/components/pdf/pages/`, un export nommé identique au
+nom de fichier (`PDFPageEvacuationApnee.tsx` → `export const
+PDFPageEvacuationApnee`). Certaines pages exigent des props (données de
+sortie, membres…) : créer un petit JSON de fixture et le passer via `--props`.
+Si le composant plante sans props, le script affiche l'erreur de la console
+navigateur.
+
+## Prérequis (gérés automatiquement par le script)
+
+- `playwright-core` (installé via `npm i --no-save` si absent)
+- Chromium Playwright (installé via `npx playwright install chromium` si absent)
+
+## Pièges html2canvas connus dans ce projet
+
+- `align-items: center`/`baseline` sur des flex : décalages verticaux →
+  préférer `flex-end` + hauteurs fixes (`height`/`lineHeight` explicites).
+- Texte posé sur une bordure basse : risque d'effet « barré » → positionner la
+  règle en `position: absolute; bottom: 0` et le texte 2px au-dessus.
+- Divs vides dans un flex `baseline` : la ligne « flotte » au-dessus du texte.

--- a/.claude/skills/verify-pdf/render-pdf-page.mjs
+++ b/.claude/skills/verify-pdf/render-pdf-page.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Renders a PDF page component through the real html2canvas pipeline and
+ * saves a screenshot of the resulting canvas — i.e. the exact pixels that
+ * will end up in the generated PDF.
+ *
+ * Usage:
+ *   node .claude/skills/verify-pdf/render-pdf-page.mjs <Component> \
+ *     [--props fixture.json] [--width 794] [--height 1123] [--out out.png]
+ */
+import { spawn, execSync } from "node:child_process";
+import { existsSync, globSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const args = process.argv.slice(2);
+const component = args.find((a) => !a.startsWith("--"));
+const opt = (name, def) => {
+  const i = args.indexOf(`--${name}`);
+  return i !== -1 && args[i + 1] ? args[i + 1] : def;
+};
+if (!component) {
+  console.error("Usage: render-pdf-page.mjs <Component> [--props f.json] [--width N] [--height N] [--out f.png]");
+  process.exit(1);
+}
+
+const root = process.cwd();
+const width = Number(opt("width", "794"));
+const height = Number(opt("height", "1123"));
+const out = opt("out", `/tmp/pdf-verify-${component}.png`);
+const propsFile = opt("props", null);
+const props = propsFile ? readFileSync(resolve(propsFile), "utf8") : "undefined";
+const port = 8123;
+
+const componentFile = `src/components/pdf/pages/${component}.tsx`;
+if (!existsSync(resolve(root, componentFile))) {
+  console.error(`Composant introuvable : ${componentFile}`);
+  process.exit(1);
+}
+
+// --- Locate or install a Playwright Chromium ---------------------------------
+const findChrome = () =>
+  [
+    ...globSync("/opt/pw-browsers/chromium-*/chrome-linux/chrome"),
+    ...globSync(`${process.env.HOME}/.cache/ms-playwright/chromium-*/chrome-linux/chrome`),
+  ][0];
+let chrome = findChrome();
+if (!chrome) {
+  console.log("Installation de Chromium (playwright)...");
+  execSync("npx -y playwright install chromium", { stdio: "inherit" });
+  chrome = findChrome();
+}
+if (!chrome) {
+  console.error("Chromium introuvable après installation.");
+  process.exit(1);
+}
+
+// --- Ensure playwright-core is importable ------------------------------------
+let pwPath = resolve(root, "node_modules/playwright-core/index.mjs");
+if (!existsSync(pwPath)) {
+  console.log("Installation de playwright-core (sans modifier package.json)...");
+  execSync("npm i --no-save playwright-core", { cwd: root, stdio: "inherit" });
+}
+
+// --- Generate the temporary harness ------------------------------------------
+const htmlPath = resolve(root, "pdf-harness-tmp.html");
+const tsxPath = resolve(root, "src/pdf-harness-tmp.tsx");
+writeFileSync(
+  htmlPath,
+  `<!doctype html><html lang="fr"><head><meta charset="UTF-8"/><title>PDF harness</title></head>
+<body style="margin:0"><div id="root"></div><script type="module" src="/src/pdf-harness-tmp.tsx"></script></body></html>`
+);
+writeFileSync(
+  tsxPath,
+  `import { createRoot } from "react-dom/client";
+import { useEffect, useRef } from "react";
+import html2canvas from "html2canvas";
+import { ${component} } from "./components/pdf/pages/${component}";
+
+const props: any = ${props};
+
+const Harness = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    (async () => {
+      await document.fonts.ready;
+      await new Promise((r) => setTimeout(r, 600));
+      const page = ref.current?.querySelector("[data-pdf-page]") ?? ref.current?.firstElementChild;
+      if (!page) return;
+      const canvas = await html2canvas(page as HTMLElement, {
+        scale: 2, useCORS: true, allowTaint: true, logging: false,
+        backgroundColor: "#ffffff", windowWidth: ${width}, windowHeight: ${height},
+      });
+      canvas.style.width = "${width}px";
+      canvas.id = "pdf-canvas";
+      document.body.innerHTML = "";
+      document.body.appendChild(canvas);
+    })();
+  }, []);
+  return <div ref={ref} style={{ width: "${width}px" }}><${component} {...(props ?? {})} /></div>;
+};
+
+createRoot(document.getElementById("root")!).render(<Harness />);
+`
+);
+
+const cleanup = () => {
+  rmSync(htmlPath, { force: true });
+  rmSync(tsxPath, { force: true });
+};
+
+// --- Start vite, screenshot, cleanup ------------------------------------------
+const vite = spawn("npx", ["vite", "--port", String(port), "--host", "127.0.0.1", "--strictPort"], {
+  cwd: root,
+  stdio: "ignore",
+  detached: true,
+});
+
+try {
+  // Wait for the dev server
+  let up = false;
+  for (let i = 0; i < 40 && !up; i++) {
+    await new Promise((r) => setTimeout(r, 500));
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/pdf-harness-tmp.html`);
+      up = res.ok;
+    } catch { /* retry */ }
+  }
+  if (!up) throw new Error("Le serveur vite n'a pas démarré.");
+
+  const { chromium } = await import(pwPath);
+  const browser = await chromium.launch({ executablePath: chrome, args: ["--no-sandbox"] });
+  const page = await browser.newPage({ viewport: { width: width + 100, height: height + 200 } });
+  const errors = [];
+  page.on("console", (m) => m.type() === "error" && errors.push(m.text()));
+  page.on("pageerror", (e) => errors.push(String(e)));
+  await page.goto(`http://127.0.0.1:${port}/pdf-harness-tmp.html`);
+  try {
+    await page.waitForSelector("#pdf-canvas", { timeout: 30000 });
+  } catch {
+    console.error("Le canvas n'a pas été produit. Erreurs navigateur :");
+    errors.forEach((e) => console.error("  " + e));
+    throw new Error("Échec du rendu (props manquantes ?)");
+  }
+  await page.waitForTimeout(300);
+  await page.locator("#pdf-canvas").screenshot({ path: out });
+  await browser.close();
+  console.log(`Capture du rendu PDF : ${out}`);
+} finally {
+  cleanup();
+  try { process.kill(-vite.pid); } catch { /* already gone */ }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ public/             # Static assets, PWA manifest, favicons
 - **TypeScript:** Strict mode is OFF (`tsconfig.app.json`). ESLint rules for unused vars/params are disabled.
 - **Supabase types:** Auto-generated in `src/integrations/supabase/types.ts` -- regenerate via Supabase CLI, do not edit by hand.
 - **No test framework:** There are no automated tests. Validate changes by running `npm run build` and `npm run lint`.
+- **PDF pages:** Any change to a component in `src/components/pdf/pages/` MUST be visually verified with the `verify-pdf` skill (`node .claude/skills/verify-pdf/render-pdf-page.mjs <Component>`) — html2canvas renders flex alignment differently from the browser, so `npm run build` alone is not enough.
 
 ## Database
 


### PR DESCRIPTION
## Fonctionnalité

Skill projet **`verify-pdf`** : vérification visuelle des pages PDF avant de pousser.

### Pourquoi
Les PDF de l'app sont générés en capturant des composants React avec html2canvas, qui rend les alignements flex (`center`/`baseline`) différemment du navigateur — d'où les défauts corrigés dans les PR #162/#163, détectés seulement après mise en prod. Ce skill permet de voir les **pixels exacts du futur PDF** en local.

### Contenu
- `.claude/skills/verify-pdf/render-pdf-page.mjs` : rend n'importe quel composant de `src/components/pdf/pages/` via le pipeline réel (vite + React + html2canvas dans un Chromium headless) et produit une capture PNG du canvas
  - Options : `--props fixture.json` (pages nécessitant des données), `--width`/`--height` (A4 portrait par défaut), `--out`
  - Installe `playwright-core` et Chromium automatiquement si absents, nettoie ses fichiers temporaires, remonte les erreurs console du navigateur
- `.claude/skills/verify-pdf/SKILL.md` : usage + pièges html2canvas connus du projet
- `CLAUDE.md` : la vérification visuelle devient obligatoire pour toute retouche de page PDF

### Testé
Skill exécuté de bout en bout sur `PDFPageEvacuationApnee` : capture conforme au PDF généré en prod. ✅

https://claude.ai/code/session_01NHqNpvSFBz3DbUWCwQpWYG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHqNpvSFBz3DbUWCwQpWYG)_