### PR TITLE
fix(dwh): sync unique_code et date_acquisition dans dim_equipement

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -32,7 +32,8 @@
       "mcp__Vercel__list_deployments",
       "mcp__Supabase__get_logs",
       "mcp__Supabase__list_projects",
-      "mcp__Supabase__get_project"
+      "mcp__Supabase__get_project",
+      "mcp__Supabase__list_tables"
     ]
   }
 }

--- a/supabase/migrations/20260611120000_fix_dwh_dim_equipement_sync_unique_code.sql
+++ b/supabase/migrations/20260611120000_fix_dwh_dim_equipement_sync_unique_code.sql
@@ -1,0 +1,37 @@
+-- Fix DWH sync: dim_equipement.unique_code et date_acquisition n'étaient pas
+-- alimentés par le trigger trg_dwh_equipment_inventory, ce qui laissait ces
+-- colonnes à NULL pour tout matériel créé via l'app (visible dans Power BI).
+
+CREATE OR REPLACE FUNCTION public.dwh_sync_dim_equipement()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  INSERT INTO dim_equipement (
+    inventory_id, nom, description, valeur_estimee, statut,
+    unique_code, date_acquisition
+  )
+  SELECT
+    NEW.id, ec.name, ec.description, ec.estimated_value, NEW.status::text,
+    NEW.unique_code, NEW.acquired_at
+  FROM equipment_catalog ec
+  WHERE ec.id = NEW.catalog_id
+  ON CONFLICT (inventory_id) DO UPDATE SET
+    statut           = EXCLUDED.statut,
+    unique_code      = EXCLUDED.unique_code,
+    date_acquisition = EXCLUDED.date_acquisition,
+    updated_at       = now();
+  RETURN NEW;
+END;
+$function$;
+
+-- Backfill des lignes existantes laissées avec NULL par l'ancienne version.
+UPDATE dim_equipement d
+SET unique_code      = ei.unique_code,
+    date_acquisition = ei.acquired_at,
+    updated_at       = now()
+FROM equipment_inventory ei
+WHERE d.inventory_id = ei.id
+  AND (d.unique_code IS NULL OR d.date_acquisition IS NULL);


### PR DESCRIPTION
## Contexte

Après la mise en place de la saisie en masse du matériel (#130), les colonnes `unique_code` et `date_acquisition` apparaissaient à `null` dans Power BI pour tout matériel créé via l'app.

## Cause

Le trigger `trg_dwh_equipment_inventory` appelle `dwh_sync_dim_equipement()`, qui copiait seulement `nom`, `description`, `valeur_estimee` et `statut` — `unique_code` et `acquired_at` étaient ignorés. Les lignes côté `equipment_inventory` étaient pourtant bien remplies (trigger `generate_equipment_code` + `acquired_at DEFAULT now()`) — seul le DWH était désynchronisé.

## Correctif

- `CREATE OR REPLACE` de la fonction pour ajouter `unique_code` et `date_acquisition` à l'`INSERT` et au `ON CONFLICT DO UPDATE`.
- Backfill des lignes existantes de `dim_equipement` depuis `equipment_inventory`.

## Test plan

- [ ] Appliquer la migration sur Supabase.
- [ ] Refresh Power BI → les anciennes lignes affichent leur code `EQ-XXXXXXXX` et leur date d'acquisition.
- [ ] Créer un nouvel article (mono + saisie en masse) → vérifier qu'il apparaît avec code et date dans `dim_equipement`.

https://claude.ai/code/session_01NasT2pKdykiXrNem7vLpCi

---
_Generated by [Claude Code](https://claude.ai/code/session_01NasT2pKdykiXrNem7vLpCi)_