### PR TITLE
chore: permissions Supabase MCP supplémentaires

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -33,7 +33,9 @@
       "mcp__Supabase__get_logs",
       "mcp__Supabase__list_projects",
       "mcp__Supabase__get_project",
-      "mcp__Supabase__list_tables"
+      "mcp__Supabase__list_tables",
+      "mcp__Supabase__get_advisors",
+      "mcp__Supabase__list_migrations"
     ]
   }
 }


### PR DESCRIPTION
Ajoute `mcp__Supabase__get_advisors` et `mcp__Supabase__list_migrations` à l'allowlist (`.claude/settings.local.json`), pour les sessions Claude Code locales.

Note : dans les sessions web, les outils d'écriture Supabase (`execute_sql`, `apply_migration`) restent soumis à l'approbation du connecteur côté claude.ai — l'allowlist locale ne s'applique pas.

https://claude.ai/code/session_01NasT2pKdykiXrNem7vLpCi

---
_Generated by [Claude Code](https://claude.ai/code/session_01NasT2pKdykiXrNem7vLpCi)_