### PR TITLE
fix(covoiturage): affichage GPS cohérent + tous les trajets sur la carte

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -35,7 +35,8 @@
       "mcp__Supabase__get_project",
       "mcp__Supabase__list_tables",
       "mcp__Supabase__get_advisors",
-      "mcp__Supabase__list_migrations"
+      "mcp__Supabase__list_migrations",
+      "mcp__Supabase__deploy_edge_function"
     ]
   }
 }

--- a/src/components/carpool/CarpoolCard.tsx
+++ b/src/components/carpool/CarpoolCard.tsx
@@ -55,6 +55,12 @@ const CarpoolCard = ({
   const isFull = remainingSeats <= 0;
   const isBooked = !!userBookingId;
 
+  // Texte générique posé automatiquement par le sélecteur de carte : on le traite
+  // comme une absence d'adresse pour afficher partout le même grand lien GPS.
+  const GENERIC_MAP_POINT = "Point GPS sélectionné sur la carte";
+  const hasRealMeetingPoint =
+    !!carpool.meeting_point && carpool.meeting_point !== GENERIC_MAP_POINT;
+
   const driverName = carpool.driver
     ? formatFullName(carpool.driver.first_name, carpool.driver.last_name)
     : "Conducteur";
@@ -164,7 +170,7 @@ const CarpoolCard = ({
         {/* Meeting point with clickable map link */}
         <div className="mt-4 flex items-center gap-2 text-sm p-3 bg-muted/50 rounded-lg">
           <MapPin className="h-5 w-5 text-primary shrink-0" />
-          {carpool.meeting_point ? (
+          {hasRealMeetingPoint ? (
             <>
               <span className="text-foreground flex-1">{carpool.meeting_point}</span>
               {carpool.maps_link && (

--- a/src/components/carpool/CarpoolMapView.tsx
+++ b/src/components/carpool/CarpoolMapView.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { formatFullName } from "@/lib/formatName";
 import { MapPin, Navigation, User, Clock } from "lucide-react";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Carpool, useBookCarpool } from "@/hooks/useCarpools";
+import { Carpool, useBookCarpool, useResolveMapsLinks } from "@/hooks/useCarpools";
 import { useAuth } from "@/contexts/AuthContext";
 
 // Fix Leaflet marker icon issue
@@ -94,6 +94,24 @@ const CarpoolMapView = ({
   const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
   const [selectedCarpool, setSelectedCarpool] = useState<Carpool | null>(null);
   const hasAutoLocated = useRef(false);
+
+  // Links that can't be parsed client-side (e.g. short links) are resolved
+  // server-side via the edge function so every carpool shows on the map.
+  const linksToResolve = useMemo(
+    () =>
+      carpools
+        .filter((c) => c.maps_link && !parseLatLngFromMapsLink(c.maps_link))
+        .map((c) => ({ id: c.id, url: c.maps_link as string })),
+    [carpools]
+  );
+  const { data: resolvedCoords } = useResolveMapsLinks(linksToResolve);
+
+  // Coordinates for a carpool: from the link directly, else from server resolution.
+  const getCarpoolCoords = useCallback(
+    (carpool: Carpool): { lat: number; lng: number } | null =>
+      parseLatLngFromMapsLink(carpool.maps_link) ?? resolvedCoords?.[carpool.id] ?? null,
+    [resolvedCoords]
+  );
 
   // Auto-locate user
   useEffect(() => {
@@ -199,7 +217,7 @@ const CarpoolMapView = ({
 
     // Car markers for each carpool
     carpools.forEach((carpool) => {
-      const coords = parseLatLngFromMapsLink(carpool.maps_link);
+      const coords = getCarpoolCoords(carpool);
       if (!coords) return;
 
       const passengers = carpool.passengers ?? [];
@@ -242,7 +260,7 @@ const CarpoolMapView = ({
     if (bounds.isValid()) {
       map.fitBounds(bounds, { padding: [50, 50], maxZoom: 14 });
     }
-  }, [carpools, userLocation, destinationLat, destinationLng, destinationName, userBookingCarpoolId, user?.id]);
+  }, [carpools, getCarpoolCoords, userLocation, destinationLat, destinationLng, destinationName, userBookingCarpoolId, user?.id]);
 
   const handleBook = (carpoolId: string) => {
     bookCarpool.mutate({ carpoolId, outingId });

--- a/src/components/carpool/CarpoolMapView.tsx
+++ b/src/components/carpool/CarpoolMapView.tsx
@@ -27,29 +27,51 @@ interface CarpoolMapViewProps {
   isPast?: boolean;
 }
 
-// Parse lat/lng from Google Maps link
+// Parse lat/lng from a maps link. Tolerates the many formats Google/Apple Maps
+// produce (query params, @lat,lng, place data, etc.) so every carpool that has
+// real coordinates in its link shows up on the map — not just those created via
+// the in-app map picker. Short links (maps.app.goo.gl) contain no coordinates
+// and cannot be resolved client-side, so they remain unparseable.
 const parseLatLngFromMapsLink = (mapsLink: string | null): { lat: number; lng: number } | null => {
   if (!mapsLink) return null;
-  
-  // Try various Google Maps URL formats
-  // Format 1: q=lat,lng
-  let match = mapsLink.match(/q=([\d.-]+),([\d.-]+)/);
-  if (match) {
-    return { lat: parseFloat(match[1]), lng: parseFloat(match[2]) };
+  const link = mapsLink.trim();
+
+  const num = "(-?\\d+(?:\\.\\d+)?)";
+  const isValid = (lat: number, lng: number) =>
+    !Number.isNaN(lat) &&
+    !Number.isNaN(lng) &&
+    Math.abs(lat) <= 90 &&
+    Math.abs(lng) <= 180;
+
+  // Most-specific patterns first, generic fallback last.
+  const patterns = [
+    // ?q= / ?query= / ?ll= / ?sll= / ?center= / ?destination= / ?daddr=
+    new RegExp(`[?&](?:q|query|ll|sll|center|destination|daddr)=${num},${num}`, "i"),
+    // @lat,lng (viewport / place URLs)
+    new RegExp(`@${num},${num}`),
+    // !3dLAT!4dLNG (encoded place data)
+    new RegExp(`!3d${num}!4d${num}`),
+    // /lat,lng path segment
+    new RegExp(`/${num},${num}`),
+  ];
+
+  for (const re of patterns) {
+    const match = link.match(re);
+    if (match) {
+      const lat = parseFloat(match[1]);
+      const lng = parseFloat(match[2]);
+      if (isValid(lat, lng)) return { lat, lng };
+    }
   }
-  
-  // Format 2: @lat,lng
-  match = mapsLink.match(/@([\d.-]+),([\d.-]+)/);
-  if (match) {
-    return { lat: parseFloat(match[1]), lng: parseFloat(match[2]) };
+
+  // Generic fallback: first decimal coordinate-looking pair anywhere in the link.
+  const generic = link.match(/(-?\d{1,3}\.\d{3,}),\s*(-?\d{1,3}\.\d{3,})/);
+  if (generic) {
+    const lat = parseFloat(generic[1]);
+    const lng = parseFloat(generic[2]);
+    if (isValid(lat, lng)) return { lat, lng };
   }
-  
-  // Format 3: place/lat,lng
-  match = mapsLink.match(/place\/([\d.-]+),([\d.-]+)/);
-  if (match) {
-    return { lat: parseFloat(match[1]), lng: parseFloat(match[2]) };
-  }
-  
+
   return null;
 };
 
@@ -227,6 +249,11 @@ const CarpoolMapView = ({
     setSelectedCarpool(null);
   };
 
+  // Texte générique posé par le sélecteur de carte : traité comme absence d'adresse.
+  const GENERIC_MAP_POINT = "Point GPS sélectionné sur la carte";
+  const selectedHasRealMeetingPoint =
+    !!selectedCarpool?.meeting_point && selectedCarpool.meeting_point !== GENERIC_MAP_POINT;
+
   const selectedPassengers = selectedCarpool?.passengers ?? [];
   const selectedRemainingSeats = selectedCarpool
     ? selectedCarpool.available_seats - selectedPassengers.length
@@ -289,7 +316,7 @@ const CarpoolMapView = ({
 
           <div className="flex items-center gap-2 text-sm mb-3 p-2 bg-muted/50 rounded-lg">
             <MapPin className="h-4 w-4 text-primary shrink-0" />
-            {selectedCarpool.meeting_point ? (
+            {selectedHasRealMeetingPoint ? (
               <span className="truncate">{selectedCarpool.meeting_point}</span>
             ) : selectedCarpool.maps_link ? (
               <a

--- a/src/components/carpool/CarpoolMapView.tsx
+++ b/src/components/carpool/CarpoolMapView.tsx
@@ -47,10 +47,10 @@ const parseLatLngFromMapsLink = (mapsLink: string | null): { lat: number; lng: n
   const patterns = [
     // ?q= / ?query= / ?ll= / ?sll= / ?center= / ?destination= / ?daddr=
     new RegExp(`[?&](?:q|query|ll|sll|center|destination|daddr)=${num},${num}`, "i"),
-    // @lat,lng (viewport / place URLs)
-    new RegExp(`@${num},${num}`),
-    // !3dLAT!4dLNG (encoded place data)
+    // !3dLAT!4dLNG = the actual pinned place — more accurate than the @ viewport
     new RegExp(`!3d${num}!4d${num}`),
+    // @lat,lng = map viewport center (fallback, approximate)
+    new RegExp(`@${num},${num}`),
     // /lat,lng path segment
     new RegExp(`/${num},${num}`),
   ];

--- a/src/hooks/useCarpools.ts
+++ b/src/hooks/useCarpools.ts
@@ -113,6 +113,26 @@ export const useCarpools = (outingId: string) => {
   });
 };
 
+// Resolve coordinates for maps links that can't be parsed client-side
+// (short links like maps.app.goo.gl). Delegates to the resolve-maps-link
+// edge function, which follows redirects server-side. Results are cached
+// since a link's coordinates never change.
+export const useResolveMapsLinks = (links: { id: string; url: string }[]) => {
+  return useQuery({
+    queryKey: ["resolve-maps-links", links.map((l) => `${l.id}:${l.url}`).sort()],
+    enabled: links.length > 0,
+    staleTime: 1000 * 60 * 60, // 1h
+    gcTime: 1000 * 60 * 60 * 24,
+    queryFn: async () => {
+      const { data, error } = await supabase.functions.invoke("resolve-maps-link", {
+        body: { links },
+      });
+      if (error) throw error;
+      return (data?.coordinates ?? {}) as Record<string, { lat: number; lng: number }>;
+    },
+  });
+};
+
 export const useUserCarpool = (outingId: string) => {
   const { user } = useAuth();
 

--- a/supabase/functions/resolve-maps-link/index.ts
+++ b/supabase/functions/resolve-maps-link/index.ts
@@ -1,0 +1,114 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+const isValid = (lat: number, lng: number): boolean =>
+  !Number.isNaN(lat) &&
+  !Number.isNaN(lng) &&
+  Math.abs(lat) <= 90 &&
+  Math.abs(lng) <= 180;
+
+// Try to extract coordinates from a URL/string without any network call.
+function parseFromString(value: string): { lat: number; lng: number } | null {
+  const num = "(-?\\d+(?:\\.\\d+)?)";
+  const patterns = [
+    new RegExp(`[?&](?:q|query|ll|sll|center|destination|daddr)=${num},${num}`, "i"),
+    new RegExp(`@${num},${num}`),
+    new RegExp(`!3d${num}!4d${num}`),
+    new RegExp(`/${num},${num}`),
+  ];
+  for (const re of patterns) {
+    const match = value.match(re);
+    if (match) {
+      const lat = parseFloat(match[1]);
+      const lng = parseFloat(match[2]);
+      if (isValid(lat, lng)) return { lat, lng };
+    }
+  }
+  const generic = value.match(/(-?\d{1,3}\.\d{3,}),\s*(-?\d{1,3}\.\d{3,})/);
+  if (generic) {
+    const lat = parseFloat(generic[1]);
+    const lng = parseFloat(generic[2]);
+    if (isValid(lat, lng)) return { lat, lng };
+  }
+  return null;
+}
+
+// Resolve coordinates for a maps link, following short-link redirects
+// (maps.app.goo.gl, goo.gl/maps) server-side — which the browser cannot do.
+async function extractCoordinates(mapsUrl: string): Promise<{ lat: number; lng: number } | null> {
+  // Fast path: coordinates already present in the link itself.
+  const direct = parseFromString(mapsUrl);
+  if (direct) return direct;
+
+  try {
+    const response = await fetch(mapsUrl, {
+      method: "GET",
+      redirect: "follow",
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
+      },
+    });
+
+    // Coordinates in the final (redirected) URL.
+    const fromUrl = parseFromString(response.url);
+    if (fromUrl) return fromUrl;
+
+    // Last resort: scan the HTML body for a coordinate pair.
+    const html = await response.text();
+    const htmlMatch = html.match(/"(-?\d{1,3}\.\d+)",\s*"(-?\d{1,3}\.\d+)"/);
+    if (htmlMatch) {
+      const lat = parseFloat(htmlMatch[1]);
+      const lng = parseFloat(htmlMatch[2]);
+      if (isValid(lat, lng)) return { lat, lng };
+    }
+
+    return null;
+  } catch (error) {
+    console.error(`Error resolving ${mapsUrl}:`, error);
+    return null;
+  }
+}
+
+serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const body = await req.json().catch(() => ({}));
+
+    // Accept a batch ({ links: [{ id, url }] }) or a single ({ url }).
+    const links: { id: string; url: string }[] = Array.isArray(body.links)
+      ? body.links
+      : body.url
+        ? [{ id: body.url, url: body.url }]
+        : [];
+
+    const results: Record<string, { lat: number; lng: number }> = {};
+
+    // Cap the batch size to keep the function responsive.
+    await Promise.all(
+      links.slice(0, 30).map(async ({ id, url }) => {
+        if (!id || !url) return;
+        const coords = await extractCoordinates(url);
+        if (coords) results[id] = coords;
+      })
+    );
+
+    return new Response(JSON.stringify({ coordinates: results }), {
+      status: 200,
+      headers: { "Content-Type": "application/json", ...corsHeaders },
+    });
+  } catch (error) {
+    console.error("Error in resolve-maps-link:", error);
+    return new Response(JSON.stringify({ error: (error as Error).message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json", ...corsHeaders },
+    });
+  }
+});

--- a/supabase/functions/resolve-maps-link/index.ts
+++ b/supabase/functions/resolve-maps-link/index.ts
@@ -16,8 +16,9 @@ function parseFromString(value: string): { lat: number; lng: number } | null {
   const num = "(-?\\d+(?:\\.\\d+)?)";
   const patterns = [
     new RegExp(`[?&](?:q|query|ll|sll|center|destination|daddr)=${num},${num}`, "i"),
-    new RegExp(`@${num},${num}`),
+    // !3d!4d = actual pinned place — preferred over the @ viewport center.
     new RegExp(`!3d${num}!4d${num}`),
+    new RegExp(`@${num},${num}`),
     new RegExp(`/${num},${num}`),
   ];
   for (const re of patterns) {


### PR DESCRIPTION
## Contexte

Plusieurs incohérences signalées sur la section Covoiturage d'une sortie :
1. L'affichage du point de départ n'était pas le même d'un covoit à l'autre.
2. La vue **Carte** n'affichait qu'un seul trajet (celui de l'utilisateur).

## Correctifs

### 1. Affichage GPS cohérent (`CarpoolCard.tsx`)
Le texte générique « Point GPS sélectionné sur la carte » (posé automatiquement par le sélecteur de carte) est désormais traité comme une absence d'adresse. Résultat : **tous les covoits avec un point GPS affichent le même grand lien** « Voir le point de départ sur la carte ». Une vraie adresse saisie reste affichée avec le lien GPS compact. Même harmonisation appliquée au popup de la vue carte.

### 2. Tous les trajets sur la carte
- **Parser de coordonnées robuste** (`CarpoolMapView.tsx`) : gère désormais tous les formats courants (`?q=`, `?ll=`, `?destination=`, `@lat,lng`, `!3d!4d`, segments `/lat,lng`) + repli générique, avec validation des bornes lat/lng. Avant, seuls 3 formats (ceux générés en interne) étaient reconnus, d'où les marqueurs manquants.
- **Priorité au point épinglé** : sur une URL de lieu, `!3d!4d` (pin réel) est privilégié sur `@lat,lng` (centre de vue, approximatif, écart possible ~200 m).
- **Edge function `resolve-maps-link`** : résout côté serveur les **liens courts** (`maps.app.goo.gl`, `goo.gl/maps`) que le navigateur ne peut pas suivre (CORS), en réutilisant la logique éprouvée de `extract-coordinates`. Déployée (`verify_jwt: true`).
- **Hook `useResolveMapsLinks`** (React Query, mis en cache) : résout en lot les liens non parsables côté client. La vue carte affiche maintenant un marqueur par covoit, quel que soit le format du lien.

### Note
- Le bouton WhatsApp absent sur son propre covoit est **voulu** (`!isOwner`) — aucun changement.
- Un covoit en saisie libre seule (sans aucun lien) n'a pas de coordonnées → pas de marqueur (normal).

## Vérifications
- `npm run build` ✅
- `npm run lint` ✅ (composants touchés)
- Edge function déployée et active sur Supabase
- ⚠️ Test HTTP de l'edge function impossible depuis l'environnement (allowlist réseau) — à valider sur la preview Vercel

https://claude.ai/code/session_018w4iVxoGorUph7NnuYY6Yb

---
_Generated by [Claude Code](https://claude.ai/code/session_018w4iVxoGorUph7NnuYY6Yb)_