### PR TITLE
fix: SECURITY DEFINER sur tous les triggers de profiles (RLS dim_compte)

### DIFF
--- a/supabase/migrations/20260611160000_fix_profiles_trigger_security_definer.sql
+++ b/supabase/migrations/20260611160000_fix_profiles_trigger_security_definer.sql
@@ -1,0 +1,22 @@
+-- Fix: toutes les fonctions trigger de la table profiles passent en SECURITY DEFINER.
+-- La migration 20260611140000 ne ciblait que les triggers nommés 'trg_dwh%'.
+-- Si la fonction de sync profiles→dim_compte a un nom différent, elle était silencieusement
+-- ignorée et continuait à s'exécuter avec le rôle authenticated (bloqué par RLS sur dim_compte).
+DO $$
+DECLARE fn regprocedure;
+BEGIN
+  FOR fn IN
+    SELECT DISTINCT t.tgfoid::regprocedure
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid = t.tgrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'profiles'
+      AND NOT t.tgisinternal
+  LOOP
+    EXECUTE format(
+      'ALTER FUNCTION %s SECURITY DEFINER SET search_path = public',
+      fn
+    );
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Problème

Lors du changement de photo de profil, une erreur s'affichait :
> `new row violates row-level security policy for table "dim_compte"`

## Cause

La migration `20260611140000_enable_rls_dwh_tables.sql` (hier) a :
1. Activé RLS sur toutes les tables DWH dont `dim_compte`
2. Tenté de passer les fonctions trigger DWH en `SECURITY DEFINER` — **mais uniquement celles dont le trigger est nommé `trg_dwh%`**

Si la fonction qui synchronise `profiles` → `dim_compte` a un nom différent de `trg_dwh_profiles`, elle était silencieusement ignorée et continuait à s'exécuter avec le rôle `authenticated`, désormais bloqué par la RLS.

## Fix

Nouvelle migration `20260611160000_fix_profiles_trigger_security_definer.sql` : passe en `SECURITY DEFINER` **toutes** les fonctions trigger de la table `profiles`, quelle que soit leur convention de nommage.

Les fonctions `SECURITY DEFINER` tournent en tant que `postgres` (propriétaire, superuser) → bypass RLS → écriture dans `dim_compte` autorisée.

La migration a déjà été appliquée manuellement en production.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FC8iYpv7bXxQfimB7mSsV4)_