### PR TITLE
fix(responsive): empêche le débordement horizontal sur l'accueil mobile

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -85,18 +85,18 @@ const Index = () => {
               </p>
             </div>
 
-            <div className="flex items-center gap-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
               {canUseHistoricalTool && (
                 <Button
                   variant="outline"
                   onClick={() => setShowHistoricalForm(true)}
-                  className="gap-2"
+                  className="w-full gap-2 sm:w-auto"
                 >
                   <History className="h-4 w-4" />
                   Archives / Saisie passée
                 </Button>
               )}
-              <Button asChild variant="outline" className="gap-2">
+              <Button asChild variant="outline" className="w-full gap-2 sm:w-auto">
                 <a href="https://clean-data-collector.lovable.app" target="_blank" rel="noopener noreferrer">
                   <ExternalLink className="h-4 w-4" />
                   Caractérisation


### PR DESCRIPTION
## Problème

Sur mobile, la page d'accueil (« Prochaines sorties ») **débordait horizontalement** : le bandeau ne remplissait pas l'écran, les boutons de filtre se tassaient en colonne à droite et « Dépollution » était tronqué.

## Cause

Dans `Index.tsx`, la rangée d'actions (boutons *Archives / Saisie passée*, *Caractérisation* + le composant `OutingFilters`) utilisait `flex items-center gap-3` **sans `flex-wrap` ni adaptation mobile**. Sur petit écran, ces éléments forçaient une largeur de contenu supérieure au viewport → défilement horizontal et tassement des filtres.

## Correctif

La rangée passe en **`flex-col` sur mobile** (boutons pleine largeur) et **`sm:flex-row sm:flex-wrap sm:items-center`** au-delà → tout reste dans le viewport, plus aucun débordement.

## Pistes écartées (vérifiées)
- `OutingFilters` utilise déjà `flex-wrap` (OK)
- Meta `viewport` correct (`width=device-width, initial-scale=1`)
- Header `sticky` + nav mobile `overflow-x-auto` gèrent leur propre scroll
- Envisagé puis **rejeté** : `overflow-x-hidden` global sur `<main>` — forcerait `overflow-y: auto` et casserait le scroll/sticky sur toutes les pages longues. Correction limitée à la source.

## Vérification
- `npm run build` ✅
- Vérification visuelle headless impossible dans l'environnement (téléchargement Chromium bloqué par la politique réseau) → **à confirmer sur la preview Vercel**

https://claude.ai/code/session_01RDbvix5XPRARXKM8LxAkvT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDbvix5XPRARXKM8LxAkvT)_