### PR TITLE
feat(poss): page finale avec la carte satellite en grand

### DIFF
--- a/src/components/poss/POSSGenerator.ts
+++ b/src/components/poss/POSSGenerator.ts
@@ -765,6 +765,42 @@ export const generatePOSS = async (data: POSSData): Promise<void> => {
   });
 
   // ====================
+  // PAGE CARTE EN GRAND (fin du document)
+  // ====================
+  if (satelliteBase64) {
+    doc.addPage();
+    let mapPageY = margin;
+
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(13);
+    doc.setTextColor("#0369a1");
+    doc.text("CARTE SATELLITE (VUE DÉTAILLÉE)", pageWidth / 2, mapPageY + 2, { align: "center" });
+    doc.setTextColor("#000000");
+    mapPageY += 8;
+
+    const availW = contentWidth;
+    const availH = pageHeight - mapPageY - margin;
+    let bigW = availW;
+    let bigH = availH;
+    try {
+      const props = doc.getImageProperties(satelliteBase64);
+      const ratio = props.width / props.height;
+      bigW = availW;
+      bigH = bigW / ratio;
+      if (bigH > availH) {
+        bigH = availH;
+        bigW = bigH * ratio;
+      }
+    } catch {
+      bigW = availW;
+      bigH = availH;
+    }
+    const bigX = margin + (contentWidth - bigW) / 2;
+    const bigY = mapPageY + (availH - bigH) / 2; // center vertically
+    doc.addImage(satelliteBase64, "PNG", bigX, bigY, bigW, bigH);
+  }
+
+  // ====================
   // Save PDF
   // ====================
   const siteName = location?.name?.replace(/\s+/g, "_") || "Sortie";


### PR DESCRIPTION
## Page carte en grand

La carte de la page 1 reste petite (≈ 62 mm de haut). Ajout d'une **dernière page dédiée** affichant **uniquement la carte satellite en grand**.

### Détails
- Carte centrée (horizontalement et verticalement), **ratio préservé** (pas de déformation), occupant quasiment toute la page : ~150 mm de haut pour une image 16:9 (≈ 2,4× la taille de l'aperçu page 1).
- Titre « CARTE SATELLITE (VUE DÉTAILLÉE) ».
- Page ajoutée uniquement si une carte satellite est disponible.

## Vérification
- `npm run build` ✅
- Calcul de dimensionnement vérifié (267×150 mm pour du 16:9, 224×172 mm pour un format plus carré) ; même logique de préservation du ratio que la carte de la page 1 déjà validée visuellement.

https://claude.ai/code/session_01RDbvix5XPRARXKM8LxAkvT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDbvix5XPRARXKM8LxAkvT)_