### PR TITLE
fix: sorties passées visibles uniquement dans Mes Sorties

### DIFF
--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -91,9 +91,9 @@ export interface Outing {
   reservations?: Reservation[];
 }
 
-export const useOutings = (typeFilter?: OutingType | null) => {
+export const useOutings = (typeFilter?: OutingType | null, includePastUnarchived = false) => {
   return useQuery({
-    queryKey: ["outings", typeFilter],
+    queryKey: ["outings", typeFilter, includePastUnarchived],
     queryFn: async () => {
       const now = new Date();
       
@@ -117,10 +117,10 @@ export const useOutings = (typeFilter?: OutingType | null) => {
 
       if (error) throw error;
       
-      // Keep upcoming outings AND past ones not yet archived (so they don't vanish)
       const upcomingOutings = data?.filter(outing => {
         const endDate = outing.end_date ? new Date(outing.end_date) : new Date(outing.date_time);
-        return endDate > now || !outing.is_archived;
+        if (includePastUnarchived) return endDate > now || !outing.is_archived;
+        return endDate > now;
       }) ?? [];
       
       // Fetch real confirmed counts and organizer max depths

--- a/src/pages/MesSorties.tsx
+++ b/src/pages/MesSorties.tsx
@@ -40,7 +40,7 @@ const MesSorties = () => {
   const { user, loading: authLoading } = useAuth();
   const { isOrganizer, isAdmin, loading: roleLoading } = useUserRole();
   const { data: isEncadrantFromDirectory } = useIsCurrentUserEncadrant();
-  const { data: outings, isLoading } = useOutings();
+  const { data: outings, isLoading } = useOutings(null, true);
   const { data: coInstructedOutings, isLoading: isLoadingCoInstructed } = useCoInstructedOutings();
   const { data: locations } = useLocations();
   const [copiedId, setCopiedId] = useState<string | null>(null);


### PR DESCRIPTION
Correction du bug introduit par le PR précédent : le filtre "inclure les sorties passées non-archivées" s'appliquait aussi à la page publique Sorties.

Le paramètre `includePastUnarchived` est désormais passé uniquement depuis `MesSorties.tsx`, la page publique reste inchangée.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGp7JJxgq48CYwx41RFGmr)_