### PR TITLE
fix: filtre is_archived strict pour Mes Sorties

### DIFF
--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -119,7 +119,7 @@ export const useOutings = (typeFilter?: OutingType | null, includePastUnarchived
       
       const upcomingOutings = data?.filter(outing => {
         const endDate = outing.end_date ? new Date(outing.end_date) : new Date(outing.date_time);
-        if (includePastUnarchived) return endDate > now || !outing.is_archived;
+        if (includePastUnarchived) return endDate > now || outing.is_archived === false;
         return endDate > now;
       }) ?? [];
       


### PR DESCRIPTION
Le filtre `!outing.is_archived` incluait les sorties avec `is_archived = null` (valeur possible pour d'anciennes entrées). Remplacé par `outing.is_archived === false` pour n'afficher que les sorties explicitement non-archivées.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGp7JJxgq48CYwx41RFGmr)_