### PR TITLE
fix: sorties À clôturer limitées aux 7 derniers jours

### DIFF
--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -117,9 +117,13 @@ export const useOutings = (typeFilter?: OutingType | null, includePastUnarchived
 
       if (error) throw error;
       
+      const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
       const upcomingOutings = data?.filter(outing => {
         const endDate = outing.end_date ? new Date(outing.end_date) : new Date(outing.date_time);
-        if (includePastUnarchived) return endDate > now || outing.is_archived === false;
+        if (includePastUnarchived) {
+          const recentPastUnarchived = endDate <= now && endDate >= sevenDaysAgo && outing.is_archived === false;
+          return endDate > now || recentPastUnarchived;
+        }
         return endDate > now;
       }) ?? [];
       


### PR DESCRIPTION
Une sortie passée non-archivée n'apparaît dans Mes Sorties (avec badge "À clôturer") que si elle s'est terminée il y a moins de 7 jours. Les sorties plus anciennes restent cachées.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGp7JJxgq48CYwx41RFGmr)_