### PR TITLE
fix: boutons compte-rendu responsives sur mobile

### DIFF
--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -1028,7 +1028,7 @@ const OutingDetail = () => {
                   onChange={(e) => setSessionReport(e.target.value)}
                   className="min-h-[200px]"
                 />
-                <div className="flex gap-3 mt-4">
+                <div className="flex flex-wrap gap-3 mt-4">
                   <Button
                     variant="outline"
                     className="flex-1"


### PR DESCRIPTION
Ajout de `flex-wrap` sur le conteneur des boutons "Enregistrer le compte-rendu" / "Valider la sortie" pour qu'ils passent à la ligne sur mobile au lieu de déborder.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGp7JJxgq48CYwx41RFGmr)_