### PR TITLE
fix: cohérence compteur sorties entre profil et stats admin

### DIFF
--- a/src/components/admin/StatsContent.tsx
+++ b/src/components/admin/StatsContent.tsx
@@ -161,27 +161,32 @@ const StatsContent = ({ isAdmin }: StatsContentProps) => {
       // Group by member (using member_id from club_members_directory as key for historical)
       const memberMap = new Map<string, MemberPresence>();
       
-      // Process regular reservations
+      // Process regular reservations — use club_members_directory key when email matches, to merge with historical entries
       reservations?.forEach((r: any) => {
         const userId = r.user_id;
-        if (!memberMap.has(userId)) {
-          const profile = profileMap.get(userId);
-          memberMap.set(userId, {
-            id: userId,
+        const profile = profileMap.get(userId);
+        const clubMember = profile?.email ? emailToClubMemberMap.get(profile.email.toLowerCase()) : null;
+        const key = clubMember ? `historical_${clubMember.id}` : userId;
+
+        if (!memberMap.has(key)) {
+          memberMap.set(key, {
+            id: key,
             name: profile?.name || "Inconnu",
-            memberCode: profile?.code || "",
+            memberCode: clubMember?.member_id || profile?.code || "",
             outings: [],
             totalPresences: 0,
             isEncadrant: profile?.isEncadrant || false
           });
         }
-        const member = memberMap.get(userId)!;
-        member.outings.push({
-          id: r.outing.id,
-          title: r.outing.title,
-          date: r.outing.date_time
-        });
-        member.totalPresences++;
+        const member = memberMap.get(key)!;
+        if (!member.outings.some((o: any) => o.id === r.outing.id)) {
+          member.outings.push({
+            id: r.outing.id,
+            title: r.outing.title,
+            date: r.outing.date_time
+          });
+          member.totalPresences++;
+        }
       });
 
       // Process historical participants (using club_members_directory member_id as key)

--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -727,6 +727,8 @@ export const useArchiveOuting = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["outings"] });
       queryClient.invalidateQueries({ queryKey: ["outing"] });
+      queryClient.invalidateQueries({ queryKey: ["profile-outings-count"] });
+      queryClient.invalidateQueries({ queryKey: ["member-presences"] });
       toast.success("Sortie validée et archivée");
     },
     onError: (error: Error) => {

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -92,7 +92,7 @@ const Profile = () => {
       // Regular reservations
       const { count: reservCount } = await supabase
         .from("reservations")
-        .select("*", { count: "exact", head: true })
+        .select("outing:outings!inner(date_time)", { count: "exact", head: true })
         .eq("user_id", user.id)
         .eq("status", "confirmé")
         .eq("is_present", true)


### PR DESCRIPTION
Trois corrections pour aligner les chiffres entre les écrans :

**1. Profile.tsx** — La query reservations utilisait `select("*")` sans `!inner` join, ce qui faisait échouer silencieusement les filtres sur `outing.date_time`. Résultat : reservCount = 0 au lieu du bon chiffre.

**2. StatsContent.tsx** — Les présences régulières (reservations) et historiques (historical_outing_participants) étaient agrégées avec des clés différentes → une même personne apparaissait en deux lignes. Désormais, si l'email du profil matche un entrée club_members_directory, les deux sources fusionnent dans la même ligne.

**3. useArchiveOuting** — L'archivage n'invalidait pas les queries `profile-outings-count` et `member-presences`, donc les compteurs ne se rafraîchissaient pas après validation d'une sortie.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGp7JJxgq48CYwx41RFGmr)_