### PR TITLE
feat: agrandir photo trombinoscope + zoom photos souvenirs/archives

### DIFF
--- a/src/pages/Archives.tsx
+++ b/src/pages/Archives.tsx
@@ -34,6 +34,7 @@ const Archives = () => {
   const [reportDraft, setReportDraft] = useState<string>("");
   const [editingHistoricalOuting, setEditingHistoricalOuting] = useState<any | null>(null);
   const [selectedEncadrant, setSelectedEncadrant] = useState<string>("all");
+  const [zoomedPhoto, setZoomedPhoto] = useState<string | null>(null);
 
   const currentYear = new Date().getFullYear();
   const years = Array.from({ length: 5 }, (_, i) => currentYear - i);
@@ -692,11 +693,15 @@ const Archives = () => {
                                 {outing.photos && outing.photos.length > 0 ? (
                                   <div className="grid grid-cols-2 gap-3">
                                     {outing.photos.map((photo: string, idx: number) => (
-                                      <div key={idx} className="aspect-video rounded-lg overflow-hidden bg-muted">
+                                      <div
+                                        key={idx}
+                                        className="aspect-video rounded-lg overflow-hidden bg-muted cursor-zoom-in"
+                                        onClick={() => setZoomedPhoto(photo)}
+                                      >
                                         <img
                                           src={photo}
                                           alt={`Photo ${idx + 1}`}
-                                          className="w-full h-full object-cover"
+                                          className="w-full h-full object-cover hover:scale-105 transition-transform duration-200"
                                         />
                                       </div>
                                     ))}
@@ -774,11 +779,15 @@ const Archives = () => {
                     {outing.photos && outing.photos.length > 0 && (
                       <div className="grid grid-cols-4 gap-2 mb-3">
                         {outing.photos.map((photo: string, idx: number) => (
-                          <div key={idx} className="aspect-square rounded-md overflow-hidden bg-muted min-w-0">
+                          <div
+                            key={idx}
+                            className="aspect-square rounded-md overflow-hidden bg-muted min-w-0 cursor-zoom-in"
+                            onClick={() => setZoomedPhoto(photo)}
+                          >
                             <img
                               src={photo}
                               alt={`Photo ${idx + 1}`}
-                              className="h-full w-full object-cover"
+                              className="h-full w-full object-cover hover:scale-105 transition-transform duration-200"
                             />
                           </div>
                         ))}
@@ -816,6 +825,13 @@ const Archives = () => {
           onOpenChange={(open) => { if (!open) setEditingHistoricalOuting(null); }}
         />
       )}
+
+      {/* Photo lightbox */}
+      <Dialog open={!!zoomedPhoto} onOpenChange={(open) => !open && setZoomedPhoto(null)}>
+        <DialogContent className="max-w-4xl p-2 bg-black/90 border-0 [&>button]:text-white">
+          <img src={zoomedPhoto ?? ""} alt="Photo agrandie" className="w-full h-auto max-h-[85vh] object-contain rounded" />
+        </DialogContent>
+      </Dialog>
     </Layout>
   );
 };

--- a/src/pages/Souvenirs.tsx
+++ b/src/pages/Souvenirs.tsx
@@ -17,6 +17,7 @@ import { Navigate } from "react-router-dom";
 const Souvenirs = () => {
   const { user, loading: authLoading } = useAuth();
   const [search, setSearch] = useState("");
+  const [zoomedPhoto, setZoomedPhoto] = useState<string | null>(null);
 
   const { data: pastOutings, isLoading } = useQuery({
     queryKey: ["past-outings-souvenirs", user?.id],
@@ -258,11 +259,15 @@ const Souvenirs = () => {
                         </h4>
                         <div className="grid grid-cols-2 gap-3">
                           {outing.photos.map((photo: string, idx: number) => (
-                            <div key={idx} className="aspect-video rounded-lg overflow-hidden bg-muted">
+                            <div
+                              key={idx}
+                              className="aspect-video rounded-lg overflow-hidden bg-muted cursor-zoom-in"
+                              onClick={(e) => { e.stopPropagation(); setZoomedPhoto(photo); }}
+                            >
                               <img
                                 src={photo}
                                 alt={`Photo ${idx + 1}`}
-                                className="w-full h-full object-cover"
+                                className="w-full h-full object-cover hover:scale-105 transition-transform duration-200"
                               />
                             </div>
                           ))}
@@ -315,6 +320,13 @@ const Souvenirs = () => {
           )}
         </div>
       </section>
+
+      {/* Photo lightbox */}
+      <Dialog open={!!zoomedPhoto} onOpenChange={(open) => !open && setZoomedPhoto(null)}>
+        <DialogContent className="max-w-4xl p-2 bg-black/90 border-0 [&>button]:text-white">
+          <img src={zoomedPhoto ?? ""} alt="Photo agrandie" className="w-full h-auto max-h-[85vh] object-contain rounded" />
+        </DialogContent>
+      </Dialog>
     </Layout>
   );
 };

--- a/src/pages/Trombinoscope.tsx
+++ b/src/pages/Trombinoscope.tsx
@@ -62,7 +62,7 @@ const ContactDialog = ({ member, onClose }: ContactDialogProps) => {
       <DialogContent className="sm:max-w-xs">
         <DialogHeader>
           <div className="flex flex-col items-center gap-3 pt-2">
-            <Avatar className="h-28 w-28">
+            <Avatar className="h-36 w-36">
               {member.avatar_url && <AvatarImage src={member.avatar_url} alt={`${member.first_name} ${member.last_name}`} />}
               <AvatarFallback className={`${getAvatarColor(member.first_name + member.last_name)} text-foreground font-bold text-3xl`}>
                 {getInitials(member.first_name, member.last_name)}


### PR DESCRIPTION
- Trombinoscope : avatar du modal passe de h-28 à h-36 (144px)
- Souvenirs : photos cliquables dans la galerie de chaque sortie (lightbox plein écran)
- Archives : photos cliquables dans l'onglet galerie et les miniatures des cartes

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UjfoRhuN7i3uHsGrLxHjuw