### PR TITLE
fix: débordement mobile + onglet accident en premier

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -206,7 +206,7 @@ const Header = () => {
           className="border-t border-white/5 p-2 lg:hidden overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           style={{ background: "rgba(1,12,28,0.95)" }}
         >
-          <div className="flex w-max mx-auto gap-1">
+          <div className="flex w-max gap-1">
             {navItems.map(({ to, label, icon: Icon }) => (
               <Link key={to} to={to}>
                 <Button

--- a/src/pages/Security.tsx
+++ b/src/pages/Security.tsx
@@ -25,8 +25,14 @@ const Security = () => {
 
   // Onglet « En cas d'accident » réservé aux encadrants (masqué en vue membre simulée)
   const isEncadrant = !isMemberPreview && (isOrganizer || isEncadrantFromDirectory);
-  const defaultTab =
-    isEncadrant && searchParams.get("tab") === "accident" ? "accident" : "securite";
+  // Pour les encadrants, « En cas d'accident » est l'onglet le plus important : affiché par défaut.
+  const defaultTab = isEncadrant
+    ? searchParams.get("tab") === "securite"
+      ? "securite"
+      : searchParams.get("tab") === "regles"
+        ? "regles"
+        : "accident"
+    : "securite";
 
   return (
     <Layout>
@@ -53,11 +59,17 @@ const Security = () => {
         </div>
 
         <Tabs defaultValue={defaultTab}>
-          <TabsList className="mb-6">
-            <TabsTrigger value="securite">🤿 Sécurité en Apnée</TabsTrigger>
-            <TabsTrigger value="regles">🛡️ Règles Team Oxygen</TabsTrigger>
-            {isEncadrant && <TabsTrigger value="accident">🚑 En cas d'accident</TabsTrigger>}
-          </TabsList>
+          {/* Scrollable sur mobile pour éviter tout débordement horizontal */}
+          <div className="mb-6 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            <TabsList className="w-max">
+              {/* Pour les encadrants, « En cas d'accident » est prioritaire : placé en premier */}
+              {isEncadrant && (
+                <TabsTrigger value="accident" className="shrink-0">🚑 En cas d'accident</TabsTrigger>
+              )}
+              <TabsTrigger value="securite" className="shrink-0">🤿 Sécurité en Apnée</TabsTrigger>
+              <TabsTrigger value="regles" className="shrink-0">🛡️ Règles Team Oxygen</TabsTrigger>
+            </TabsList>
+          </div>
 
           {/* Tab 1: original security images */}
           <TabsContent value="securite">


### PR DESCRIPTION
## Corrections mobile

Résout le débordement horizontal de la page sur mobile et réordonne les onglets Sécurité.

- **Nav mobile** : suppression du centrage `mx-auto` qui coupait/rendait inaccessible la 1re entrée (« Sorties »). La ligne défile désormais depuis le début.
- **Onglets page Sécurité** : placés dans un conteneur `overflow-x-auto` → plus de débordement de la page (le titre n'est plus coupé).
- **Priorité accident** : pour les encadrants, l'onglet **« En cas d'accident »** est placé **en premier** et sélectionné **par défaut** (information la plus importante). Les membres ne sont pas affectés.

## Vérifications
- `npm run build` ✅
- `npm run lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Avvm2GGAZYr7VwP7xb4zGV)_