### PR TITLE
feat: add Hyères weather location

### DIFF
--- a/src/pages/Weather.tsx
+++ b/src/pages/Weather.tsx
@@ -29,7 +29,7 @@ const LOCATIONS = [
   { name: "Marseille", lat: 43.2965, lon: 5.3698 },
   { name: "La Ciotat", lat: 43.1748, lon: 5.6048 },
   { name: "Côte Bleue", lat: 43.3308, lon: 5.1047 },
-  { name: "Presqu'île de Giens", lat: 43.0333, lon: 6.1500 },
+  { name: "Hyères", lat: 43.0333, lon: 6.1500 },
 ];
 
 interface MarineWeatherData {

--- a/src/pages/Weather.tsx
+++ b/src/pages/Weather.tsx
@@ -29,6 +29,7 @@ const LOCATIONS = [
   { name: "Marseille", lat: 43.2965, lon: 5.3698 },
   { name: "La Ciotat", lat: 43.1748, lon: 5.6048 },
   { name: "Côte Bleue", lat: 43.3308, lon: 5.1047 },
+  { name: "Presqu'île de Giens", lat: 43.0333, lon: 6.1500 },
 ];
 
 interface MarineWeatherData {


### PR DESCRIPTION
Ajout du secteur **Hyères** (presqu'île de Giens) dans la page Météo Marine.

- Coordonnées : 43.0333°N, 6.1500°E
- Apparaît comme 4ème onglet aux côtés de Marseille, La Ciotat et Côte Bleue

---
_Generated by [Claude Code](https://claude.ai/code/session_014DAg6mgvnaFNWsgcf44eYg)_