### PR TITLE
feat: add zone shortcut buttons on map page

### DIFF
--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -40,6 +40,13 @@ L.Icon.Default.mergeOptions({
 const DEFAULT_CENTER: [number, number] = [43.2965, 5.3698];
 const DEFAULT_ZOOM = 11;
 
+const MAP_ZONES = [
+  { name: "Côte Bleue", lat: 43.3308, lon: 5.1047, zoom: 12 },
+  { name: "Marseille", lat: 43.2965, lon: 5.3698, zoom: 11 },
+  { name: "La Ciotat", lat: 43.1748, lon: 5.6048, zoom: 12 },
+  { name: "Hyères", lat: 43.0333, lon: 6.1500, zoom: 12 },
+];
+
 const getTypeIcon = (type: string | null) => {
   switch (type) {
     case "Mer":
@@ -488,6 +495,22 @@ const Map = () => {
               Visualisez tous les lieux de plongée enregistrés
               {isOrganizer && " • Cliquez sur la carte pour ajouter un lieu"}
             </p>
+          </div>
+
+          {/* Zone shortcuts */}
+          <div className="mb-4 flex flex-wrap gap-2">
+            {MAP_ZONES.map((zone) => (
+              <Button
+                key={zone.name}
+                variant="outline"
+                size="sm"
+                className="gap-2"
+                onClick={() => mapInstanceRef.current?.setView([zone.lat, zone.lon], zone.zoom)}
+              >
+                <Navigation className="h-3.5 w-3.5" />
+                {zone.name}
+              </Button>
+            ))}
           </div>
 
           <div className="grid gap-8 lg:grid-cols-4">

--- a/src/pages/Weather.tsx
+++ b/src/pages/Weather.tsx
@@ -29,7 +29,7 @@ const LOCATIONS = [
   { name: "Marseille", lat: 43.2965, lon: 5.3698 },
   { name: "La Ciotat", lat: 43.1748, lon: 5.6048 },
   { name: "Côte Bleue", lat: 43.3308, lon: 5.1047 },
-  { name: "Presqu'île de Giens", lat: 43.0333, lon: 6.1500 },
+  { name: "Hyères", lat: 43.0333, lon: 6.1500 },
 ];
 
 interface MarineWeatherData {

--- a/src/pages/Weather.tsx
+++ b/src/pages/Weather.tsx
@@ -29,6 +29,7 @@ const LOCATIONS = [
   { name: "Marseille", lat: 43.2965, lon: 5.3698 },
   { name: "La Ciotat", lat: 43.1748, lon: 5.6048 },
   { name: "Côte Bleue", lat: 43.3308, lon: 5.1047 },
+  { name: "Presqu'île de Giens", lat: 43.0333, lon: 6.1500 },
 ];
 
 interface MarineWeatherData {


### PR DESCRIPTION
Ajout de boutons de raccourcis de zones au-dessus de la carte pour zoomer rapidement sur un secteur.

**Zones disponibles :** Côte Bleue · Marseille · La Ciotat · Hyères

Un clic sur un bouton appelle `map.setView()` avec les coordonnées et le niveau de zoom appropriés au secteur.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DAg6mgvnaFNWsgcf44eYg)_