### PR TITLE
fix: move geolocation button below layer control

### DIFF
--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -523,11 +523,11 @@ const Map = () => {
                     className="h-[75vh] w-full"
                     style={{ zIndex: 0 }}
                   />
-                  {/* Geolocation button */}
+                  {/* Geolocation button — offset below Leaflet layer control (~90px) */}
                   <Button
                     variant="secondary"
                     size="icon"
-                    className="absolute top-2.5 right-2.5 z-[1000] bg-white shadow-md hover:bg-gray-100"
+                    className="absolute top-24 right-2.5 z-[1000] bg-white shadow-md hover:bg-gray-100"
                     onClick={centerOnUser}
                     disabled={isLocating}
                     title="Ma position"

--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -40,6 +40,13 @@ L.Icon.Default.mergeOptions({
 const DEFAULT_CENTER: [number, number] = [43.2965, 5.3698];
 const DEFAULT_ZOOM = 11;
 
+const MAP_ZONES = [
+  { name: "Côte Bleue", lat: 43.3308, lon: 5.1047, zoom: 12 },
+  { name: "Marseille", lat: 43.2965, lon: 5.3698, zoom: 11 },
+  { name: "La Ciotat", lat: 43.1748, lon: 5.6048, zoom: 12 },
+  { name: "Hyères", lat: 43.0333, lon: 6.1500, zoom: 12 },
+];
+
 const getTypeIcon = (type: string | null) => {
   switch (type) {
     case "Mer":
@@ -488,6 +495,22 @@ const Map = () => {
               Visualisez tous les lieux de plongée enregistrés
               {isOrganizer && " • Cliquez sur la carte pour ajouter un lieu"}
             </p>
+          </div>
+
+          {/* Zone shortcuts */}
+          <div className="mb-4 flex flex-wrap gap-2">
+            {MAP_ZONES.map((zone) => (
+              <Button
+                key={zone.name}
+                variant="outline"
+                size="sm"
+                className="gap-2"
+                onClick={() => mapInstanceRef.current?.setView([zone.lat, zone.lon], zone.zoom)}
+              >
+                <Navigation className="h-3.5 w-3.5" />
+                {zone.name}
+              </Button>
+            ))}
           </div>
 
           <div className="grid gap-8 lg:grid-cols-4">

--- a/src/pages/Weather.tsx
+++ b/src/pages/Weather.tsx
@@ -29,7 +29,7 @@ const LOCATIONS = [
   { name: "Marseille", lat: 43.2965, lon: 5.3698 },
   { name: "La Ciotat", lat: 43.1748, lon: 5.6048 },
   { name: "Côte Bleue", lat: 43.3308, lon: 5.1047 },
-  { name: "Presqu'île de Giens", lat: 43.0333, lon: 6.1500 },
+  { name: "Hyères", lat: 43.0333, lon: 6.1500 },
 ];
 
 interface MarineWeatherData {

--- a/src/pages/Weather.tsx
+++ b/src/pages/Weather.tsx
@@ -29,6 +29,7 @@ const LOCATIONS = [
   { name: "Marseille", lat: 43.2965, lon: 5.3698 },
   { name: "La Ciotat", lat: 43.1748, lon: 5.6048 },
   { name: "Côte Bleue", lat: 43.3308, lon: 5.1047 },
+  { name: "Presqu'île de Giens", lat: 43.0333, lon: 6.1500 },
 ];
 
 interface MarineWeatherData {


### PR DESCRIPTION
Le bouton de géolocalisation (`top-2.5 right-2.5`) se superposait au contrôle de calques Leaflet placé au même endroit. Déplacé à `top-24` pour le positionner juste en dessous.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DAg6mgvnaFNWsgcf44eYg)_