### PR TITLE
fix: increase comments field limit to 2000 chars and enlarge textarea

### DIFF
--- a/src/components/admin/LocationManager.tsx
+++ b/src/components/admin/LocationManager.tsx
@@ -30,7 +30,7 @@ const locationSchema = z.object({
   maps_url: z.string().url("URL invalide").optional().or(z.literal("")),
   photo_url: z.string().url("URL invalide").optional().or(z.literal("")),
   max_depth: z.coerce.number().min(0).max(200).optional().or(z.literal("")),
-  comments: z.string().max(500).optional(),
+  comments: z.string().max(2000).optional(),
 });
 
 type LocationFormData = z.infer<typeof locationSchema>;
@@ -568,8 +568,8 @@ const LocationManager = () => {
                             <Textarea
                               placeholder="Infos complémentaires, accès, particularités..."
                               {...field}
-                              className="resize-none"
-                              rows={3}
+                              className="resize-y"
+                              rows={6}
                             />
                           </FormControl>
                           <FormMessage />


### PR DESCRIPTION
- Limite de validation Zod passée de 500 à 2000 caractères
- Textarea agrandi à 6 lignes par défaut (au lieu de 3)
- `resize-none` remplacé par `resize-y` pour permettre à l'utilisateur d'agrandir manuellement si besoin

---
_Generated by [Claude Code](https://claude.ai/code/session_014DAg6mgvnaFNWsgcf44eYg)_