### PR TITLE
fix: show POSS section without requiring GPS coordinates

### DIFF
--- a/src/components/admin/LocationManager.tsx
+++ b/src/components/admin/LocationManager.tsx
@@ -595,7 +595,7 @@ const LocationManager = () => {
             </Collapsible>
 
             {/* ===== SECTION 3: PDF Cartography (collapsible) ===== */}
-            {editingLocation && editingLocation.latitude && editingLocation.longitude && (
+            {editingLocation && (
               <Collapsible>
                 <CollapsibleTrigger asChild>
                   <Button variant="ghost" className="w-full justify-start gap-2 text-base font-medium">


### PR DESCRIPTION
La section "Cartographie PDF (POSS)" était conditionnée à la présence de coordonnées GPS (`latitude && longitude`), ce qui empêchait d'y accéder pour un lieu nouvellement créé sans position encore renseignée.

La condition est assouplie : la section s'affiche dès qu'on est en mode édition d'un lieu existant, quelle que soit la présence ou non des coordonnées GPS.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DAg6mgvnaFNWsgcf44eYg)_