### PR TITLE
fix: recenter Hyères zone on the 3 islands

### DIFF
--- a/src/pages/Map.tsx
+++ b/src/pages/Map.tsx
@@ -44,7 +44,7 @@ const MAP_ZONES = [
   { name: "Côte Bleue", lat: 43.3308, lon: 5.1047, zoom: 12 },
   { name: "Marseille", lat: 43.2965, lon: 5.3698, zoom: 11 },
   { name: "La Ciotat", lat: 43.1748, lon: 5.6048, zoom: 12 },
-  { name: "Hyères", lat: 43.0333, lon: 6.1500, zoom: 12 },
+  { name: "Hyères", lat: 43.0050, lon: 6.3200, zoom: 11 },
 ];
 
 const getTypeIcon = (type: string | null) => {


### PR DESCRIPTION
Le centre de la zone Hyères pointait sur la ville (43.0333, 6.1500). Recentré sur 43.0050, 6.3200 avec zoom 11 pour englober les 3 îles : Porquerolles, Port-Cros et l'Île du Levant.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DAg6mgvnaFNWsgcf44eYg)_