### PR TITLE
fix: masquer les événements terminés dans l'agenda du club

### DIFF
--- a/supabase/functions/get-club-calendar/index.ts
+++ b/supabase/functions/get-club-calendar/index.ts
@@ -130,14 +130,20 @@ const handler = async (req: Request): Promise<Response> => {
     const icsText = await response.text();
     const events = parseICS(icsText);
 
-    // Keep events from 7 days ago to 6 months ahead
-    const past = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    const future = new Date(Date.now() + 180 * 24 * 60 * 60 * 1000);
+    // Hide events that are already over, keep anything up to 6 months ahead.
+    const now = Date.now();
+    const future = now + 180 * 24 * 60 * 60 * 1000;
 
     const filtered = events
       .filter((e) => {
-        const start = new Date(e.startDate);
-        return start >= past && start <= future;
+        const start = new Date(e.startDate).getTime();
+        // An event is "past" once it has ENDED, not once it has started.
+        // For all-day events DTEND is exclusive (midnight after the last day),
+        // so endDate is the correct cutoff. Multi-day events (e.g. "Blue Week")
+        // therefore disappear when they finish instead of lingering because
+        // their start date is still recent. Fall back to startDate when no end.
+        const end = e.endDate ? new Date(e.endDate).getTime() : start;
+        return end >= now && start <= future;
       })
       .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime());
 


### PR DESCRIPTION
## Problème

L'agenda du club affichait toujours la « Blue Week » alors que l'événement était déjà passé.

## Cause

Dans l'edge function `get-club-calendar`, les événements étaient filtrés uniquement sur leur date de **début** (avec 7 jours de tolérance en arrière). Un événement sur plusieurs jours comme la Blue Week restait donc affiché tant que sa date de début était récente, même une fois terminé — et, la liste étant triée par date de début croissante, il remontait en tête de l'agenda.

## Correctif

Le filtre se base désormais sur la date de **fin effective** (`DTEND`, exclusive pour les événements all-day) :
- un événement disparaît dès qu'il est **terminé** ;
- il reste visible tant qu'il est **en cours** ;
- les événements du jour et à venir (jusqu'à 6 mois) s'affichent normalement.

## Vérification

Logique validée par simulation : Blue Week terminée → masquée, en cours → affichée, événements du jour/futurs → affichés, événement timé passé → masqué.

⚠️ Il s'agit d'une edge function Supabase : elle est redéployée séparément via `supabase functions deploy get-club-calendar` (faite en parallèle de ce merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnkGVNwFL7wAsGWyyu7cLp)_