### PR TITLE
feat: onglet Sorties dans les statistiques (date, nom, type, participants)

### DIFF
--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Loader2, BarChart3, TrendingUp, Users, Calendar, AlertTriangle, UserCheck } from "lucide-react";
+import { Loader2, BarChart3, TrendingUp, Users, Calendar, AlertTriangle, UserCheck, ListChecks } from "lucide-react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from "recharts";
 import Layout from "@/components/layout/Layout";
@@ -44,6 +44,25 @@ interface OrganizerMonthly {
   months: number[];
   total: number;
 }
+
+interface OutingListItem {
+  id: string;
+  title: string;
+  date_time: string;
+  end_date: string | null;
+  outing_type: string;
+  max_participants: number;
+  is_past: boolean;
+  participant_count: number;
+}
+
+const TYPE_BADGE_CLASS: Record<string, string> = {
+  Mer: "bg-sky-100 text-sky-800 border-sky-200",
+  Fosse: "bg-indigo-100 text-indigo-800 border-indigo-200",
+  Piscine: "bg-cyan-100 text-cyan-800 border-cyan-200",
+  Étang: "bg-teal-100 text-teal-800 border-teal-200",
+  Dépollution: "bg-emerald-100 text-emerald-800 border-emerald-200",
+};
 
 const Stats = () => {
   const navigate = useNavigate();
@@ -178,6 +197,19 @@ const Stats = () => {
       });
 
       return Array.from(organizerMap.values()).sort((a, b) => b.total - a.total);
+    },
+    enabled: isAdmin,
+  });
+
+  // Fetch the full list of outings for the year (date, name, type, participants)
+  const { data: outingsList, isLoading: outingsLoading } = useQuery({
+    queryKey: ["outings-list", selectedYear],
+    queryFn: async () => {
+      const { data, error } = await supabase.rpc("get_outings_list", {
+        p_year: selectedYear,
+      });
+      if (error) throw error;
+      return (data as unknown as OutingListItem[]) ?? [];
     },
     enabled: isAdmin,
   });
@@ -320,10 +352,11 @@ const Stats = () => {
           </div>
 
           <Tabs defaultValue="dashboard" className="space-y-6">
-            <TabsList className="grid w-full grid-cols-4">
+            <TabsList className="grid w-full grid-cols-5">
               <TabsTrigger value="dashboard">Tableau de bord</TabsTrigger>
               <TabsTrigger value="demographics">Démographie</TabsTrigger>
               <TabsTrigger value="members">Participation</TabsTrigger>
+              <TabsTrigger value="outings">Sorties</TabsTrigger>
               <TabsTrigger value="organizers">Encadrants</TabsTrigger>
             </TabsList>
 
@@ -749,6 +782,75 @@ const Stats = () => {
                             </Dialog>
                           </div>
                         ))}
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              )}
+            </TabsContent>
+
+            {/* Outings Tab */}
+            <TabsContent value="outings">
+              {outingsLoading ? (
+                <div className="flex items-center justify-center py-12">
+                  <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                </div>
+              ) : (
+                <Card className="shadow-card">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <ListChecks className="h-5 w-5 text-primary" />
+                      Liste des sorties en {selectedYear}
+                      {outingsList && outingsList.length > 0 && (
+                        <Badge variant="secondary" className="ml-1">{outingsList.length}</Badge>
+                      )}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    {!outingsList || outingsList.length === 0 ? (
+                      <p className="text-center text-muted-foreground py-8">Aucune sortie cette année</p>
+                    ) : (
+                      <div className="overflow-x-auto">
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead className="min-w-[110px]">Date</TableHead>
+                              <TableHead className="min-w-[180px]">Nom</TableHead>
+                              <TableHead>Type</TableHead>
+                              <TableHead className="text-center">Participants</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {outingsList.map((outing) => {
+                              const start = new Date(outing.date_time);
+                              const end = outing.end_date ? new Date(outing.end_date) : null;
+                              const isMultiDay = end && end.toDateString() !== start.toDateString();
+                              return (
+                                <TableRow key={outing.id}>
+                                  <TableCell className="whitespace-nowrap text-sm">
+                                    {start.toLocaleDateString("fr-FR", { day: "2-digit", month: "short", year: "numeric" })}
+                                    {isMultiDay && (
+                                      <span className="text-muted-foreground">
+                                        {" "}→ {end!.toLocaleDateString("fr-FR", { day: "2-digit", month: "short" })}
+                                      </span>
+                                    )}
+                                  </TableCell>
+                                  <TableCell className="font-medium">{outing.title}</TableCell>
+                                  <TableCell>
+                                    <Badge variant="outline" className={TYPE_BADGE_CLASS[outing.outing_type] ?? ""}>
+                                      {outing.outing_type}
+                                    </Badge>
+                                  </TableCell>
+                                  <TableCell className="text-center">
+                                    <Badge variant="secondary" className="min-w-[28px]">
+                                      {outing.participant_count}
+                                    </Badge>
+                                  </TableCell>
+                                </TableRow>
+                              );
+                            })}
+                          </TableBody>
+                        </Table>
                       </div>
                     )}
                   </CardContent>

--- a/supabase/migrations/20260630120000_get_outings_list.sql
+++ b/supabase/migrations/20260630120000_get_outings_list.sql
@@ -1,0 +1,57 @@
+-- RPC: list every outing of a given year with date, name, type and participant count.
+-- Powers the "Sorties" tab of the club statistics page.
+-- Mirrors get_club_stats: admin-only, SECURITY DEFINER, and counts participants
+-- from both regular reservations (présents) and historical_outing_participants.
+CREATE OR REPLACE FUNCTION public.get_outings_list(p_year integer DEFAULT (EXTRACT(year FROM CURRENT_DATE))::integer)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  result JSON;
+  start_of_year TIMESTAMPTZ;
+  end_of_year TIMESTAMPTZ;
+BEGIN
+  -- Verify caller is admin
+  IF NOT has_role(auth.uid(), 'admin') THEN
+    RAISE EXCEPTION 'Unauthorized: Admin access required';
+  END IF;
+
+  start_of_year := make_timestamptz(p_year, 1, 1, 0, 0, 0);
+  end_of_year := make_timestamptz(p_year, 12, 31, 23, 59, 59);
+
+  SELECT COALESCE(json_agg(row_to_json(t) ORDER BY t.date_time DESC), '[]'::json)
+  INTO result
+  FROM (
+    SELECT
+      o.id,
+      o.title,
+      o.date_time,
+      o.end_date,
+      o.outing_type,
+      o.max_participants,
+      (o.date_time < NOW()) AS is_past,
+      -- Participant count:
+      --   past outings    -> people who actually attended (présents) or historical participants
+      --   future outings  -> confirmed registrations (inscrits) or historical participants
+      CASE WHEN o.date_time < NOW() THEN
+        GREATEST(
+          (SELECT COUNT(*) FROM reservations r WHERE r.outing_id = o.id AND r.status = 'confirmé' AND r.is_present = true),
+          (SELECT COUNT(*) FROM historical_outing_participants hop WHERE hop.outing_id = o.id)
+        )
+      ELSE
+        GREATEST(
+          (SELECT COUNT(*) FROM reservations r WHERE r.outing_id = o.id AND r.status = 'confirmé'),
+          (SELECT COUNT(*) FROM historical_outing_participants hop WHERE hop.outing_id = o.id)
+        )
+      END AS participant_count
+    FROM outings o
+    WHERE o.date_time >= start_of_year
+      AND o.date_time <= end_of_year
+      AND o.is_deleted = false
+  ) t;
+
+  RETURN result;
+END;
+$function$;


### PR DESCRIPTION
## Quoi

Ajoute un onglet **« Sorties »** à la page Statistiques (`/stats`), entre « Participation » et « Encadrants ». Il liste toutes les sorties de l'année sélectionnée sous forme de tableau :

| Date | Nom | Type | Participants |
|------|-----|------|--------------|

- **Date** : date de la sortie (avec plage `→` pour les sorties sur plusieurs jours)
- **Nom** : titre de la sortie
- **Type** : badge coloré selon le type (`Mer`, `Fosse`, `Piscine`, `Étang`, `Dépollution`)
- **Participants** : nombre de participants

## Comment

Nouveau RPC **`get_outings_list(p_year)`** (`SECURITY DEFINER`, réservé aux admins, même schéma de sécurité que `get_club_stats`). Il combine les deux sources de participants utilisées ailleurs dans les stats :
- **réservations confirmées** — présents pour les sorties passées, inscrits pour les sorties à venir ;
- **participants historiques** importés (`historical_outing_participants`).

Le tableau est trié par date décroissante. Les sorties supprimées (`is_deleted`) sont exclues.

## Notes

- Certaines sorties passées peuvent afficher `0` participant lorsqu'aucune présence n'a été saisie et qu'il n'y a pas de participants historiques — c'est fidèle aux données.
- Migration `supabase/migrations/20260630120000_get_outings_list.sql` déjà appliquée sur le projet de prod en parallèle de ce merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnkGVNwFL7wAsGWyyu7cLp)_