### PR TITLE
feat: image de couverture optionnelle pour une sortie

### DIFF
--- a/src/components/admin/CreateOutingForm.tsx
+++ b/src/components/admin/CreateOutingForm.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useQuery } from "@tanstack/react-query";
-import { CalendarIcon, Plus, Share2, Check, Copy, ShieldAlert, Car, Minus, Ship, Footprints, MapPin, Users, X } from "lucide-react";
+import { CalendarIcon, Plus, Share2, Check, Copy, ShieldAlert, Car, Minus, Ship, Footprints, MapPin, Users, X, ImagePlus, Loader2, Trash2 } from "lucide-react";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { Button } from "@/components/ui/button";
@@ -76,6 +76,46 @@ const CreateOutingForm = ({ prefilledLocationId, prefilledLocationName, onClose 
   const [selectedCoInstructors, setSelectedCoInstructors] = useState<{ id: string; first_name: string; last_name: string }[]>([]);
   const [coInstructorSearch, setCoInstructorSearch] = useState("");
   const [coInstructorPickerOpen, setCoInstructorPickerOpen] = useState(false);
+  const [coverImageUrl, setCoverImageUrl] = useState<string | null>(null);
+  const [isUploadingCover, setIsUploadingCover] = useState(false);
+
+  const handleCoverUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith("image/")) {
+      toast.error("Veuillez sélectionner une image");
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error("L'image ne doit pas dépasser 5 Mo");
+      return;
+    }
+
+    setIsUploadingCover(true);
+    try {
+      const fileExt = file.name.split(".").pop();
+      const filePath = `outings/cover-${Date.now()}.${fileExt}`;
+
+      const { error: uploadError } = await supabase.storage
+        .from("outings_gallery")
+        .upload(filePath, file);
+      if (uploadError) throw uploadError;
+
+      const { data: { publicUrl } } = supabase.storage
+        .from("outings_gallery")
+        .getPublicUrl(filePath);
+
+      setCoverImageUrl(publicUrl);
+      toast.success("Image ajoutée");
+    } catch (error) {
+      console.error("Cover upload error:", error);
+      toast.error("Erreur lors de l'upload : " + (error instanceof Error ? error.message : String(error)));
+    } finally {
+      setIsUploadingCover(false);
+      event.target.value = "";
+    }
+  };
 
   const { data: allMembers } = useQuery({
     queryKey: ["encadrants-picker"],
@@ -294,6 +334,12 @@ const CreateOutingForm = ({ prefilledLocationId, prefilledLocationName, onClose 
         onSuccess: async (newOuting) => {
           form.reset();
           if (newOuting?.id) {
+            if (coverImageUrl) {
+              await supabase
+                .from("outings")
+                .update({ cover_image_url: coverImageUrl })
+                .eq("id", newOuting.id);
+            }
             if (selectedCoInstructors.length > 0) {
               await supabase.from("outing_co_instructors").insert(
                 selectedCoInstructors.map((ci) => ({ outing_id: newOuting.id, user_id: ci.id }))
@@ -304,6 +350,7 @@ const CreateOutingForm = ({ prefilledLocationId, prefilledLocationName, onClose 
               );
             }
             setSelectedCoInstructors([]);
+            setCoverImageUrl(null);
             setCreatedOutingId(newOuting.id);
             setShowShareDialog(true);
           }
@@ -381,6 +428,49 @@ const CreateOutingForm = ({ prefilledLocationId, prefilledLocationName, onClose 
                 </FormItem>
               )}
             />
+
+            {/* Image de couverture (optionnelle) */}
+            <FormItem>
+              <FormLabel>Image de la sortie (optionnel)</FormLabel>
+              <FormDescription className="text-xs">
+                Si vide, la photo du lieu sera utilisée.
+              </FormDescription>
+              {coverImageUrl ? (
+                <div className="relative mt-1 overflow-hidden rounded-lg border border-border">
+                  <img src={coverImageUrl} alt="Aperçu" className="h-36 w-full object-cover" />
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="icon"
+                    className="absolute top-2 right-2 h-8 w-8"
+                    onClick={() => setCoverImageUrl(null)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              ) : (
+                <label
+                  className={cn(
+                    "mt-1 flex h-24 cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-border bg-muted/30 text-sm text-muted-foreground transition-colors hover:bg-muted/50",
+                    isUploadingCover && "pointer-events-none opacity-60"
+                  )}
+                >
+                  {isUploadingCover ? (
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  ) : (
+                    <ImagePlus className="h-5 w-5" />
+                  )}
+                  <span>{isUploadingCover ? "Envoi..." : "Ajouter une image (max 5 Mo)"}</span>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleCoverUpload}
+                    disabled={isUploadingCover}
+                  />
+                </label>
+              )}
+            </FormItem>
 
             <div className="grid gap-4 sm:grid-cols-2">
               <FormField

--- a/src/components/outings/OutingCard.tsx
+++ b/src/components/outings/OutingCard.tsx
@@ -86,6 +86,8 @@ const OutingCard = ({ outing, carpoolInfo }: OutingCardProps) => {
   const Icon = typeIcons[outing.outing_type];
   const WeatherIcon = weatherIcons[outing.outing_type];
   const locationPhoto = (outing.location_details as any)?.photo_url || null;
+  // Priority: outing's own cover image → location photo → placeholder
+  const coverImage = outing.cover_image_url || locationPhoto;
   const locationCoords = {
     latitude: outing.location_details?.latitude,
     longitude: outing.location_details?.longitude,
@@ -117,7 +119,7 @@ const OutingCard = ({ outing, carpoolInfo }: OutingCardProps) => {
       {/* Location photo header */}
       <div className="relative h-32 overflow-hidden">
         <img
-          src={locationPhoto || PLACEHOLDER_IMAGE}
+          src={coverImage || PLACEHOLDER_IMAGE}
           alt={displayLocation}
           className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-110"
           loading="lazy"

--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -50,6 +50,7 @@ export interface Outing {
   outing_type: OutingType;
   max_participants: number;
   session_report: string | null;
+  cover_image_url: string | null;
   water_entry_time: string | null;
   water_exit_time: string | null;
   created_at: string;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -515,6 +515,7 @@ export type Database = {
         Row: {
           boat_id: string | null
           created_at: string | null
+          cover_image_url: string | null
           date_time: string
           description: string | null
           dive_mode: string | null
@@ -541,6 +542,7 @@ export type Database = {
         Insert: {
           boat_id?: string | null
           created_at?: string | null
+          cover_image_url?: string | null
           date_time: string
           description?: string | null
           dive_mode?: string | null
@@ -567,6 +569,7 @@ export type Database = {
         Update: {
           boat_id?: string | null
           created_at?: string | null
+          cover_image_url?: string | null
           date_time?: string
           description?: string | null
           dive_mode?: string | null

--- a/src/pages/OutingView.tsx
+++ b/src/pages/OutingView.tsx
@@ -188,7 +188,8 @@ const OutingView = () => {
   const isFull = confirmedReservations.length >= outing.max_participants;
   
   const locationDetails = outing.location_details as any;
-  const locationPhoto = locationDetails?.photo_url || null;
+  // Priority: outing's own cover image → location photo → placeholder
+  const locationPhoto = (outing as any).cover_image_url || locationDetails?.photo_url || null;
   const locationCoords = {
     latitude: locationDetails?.latitude,
     longitude: locationDetails?.longitude,

--- a/supabase/migrations/20260630140000_outings_cover_image.sql
+++ b/supabase/migrations/20260630140000_outings_cover_image.sql
@@ -1,0 +1,4 @@
+-- Optional cover image for an outing. When set, it is displayed instead of the
+-- location photo on the outing card / detail view. Kept separate from the
+-- `photos` array (which is the post-event souvenir gallery) so the two don't mix.
+ALTER TABLE public.outings ADD COLUMN IF NOT EXISTS cover_image_url text;


### PR DESCRIPTION
## Quoi

À la **création d'une sortie**, on peut maintenant **uploader une image**. Si aucune image n'est fournie, la **photo du lieu** est utilisée (puis un placeholder en dernier recours).

## Comment

- Nouvelle colonne **`outings.cover_image_url`** — volontairement séparée du tableau `photos[]` (qui sert de galerie « souvenirs » post-sortie, page Souvenirs), pour ne pas mélanger les deux.
- Champ d'upload dans `CreateOutingForm` : envoi dans le bucket `outings_gallery` (policy existante : admins + organisateurs), aperçu + suppression possible avant validation. Après création de la sortie, la colonne `cover_image_url` est renseignée.
- Affichage avec priorité **image de la sortie → photo du lieu → placeholder** dans `OutingCard` (liste) et `OutingView` (détail).

## Notes

- Migration `supabase/migrations/20260630140000_outings_cover_image.sql` déjà appliquée en prod, types Supabase mis à jour.
- Périmètre : création + affichage. L'ajout/modification de l'image depuis l'édition d'une sortie existante pourra être ajouté ensuite si besoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnkGVNwFL7wAsGWyyu7cLp)_