### PR TITLE
feat: afficher l'image de couverture sur la fiche de gestion de sortie

### DIFF
--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -250,6 +250,8 @@ const OutingDetail = () => {
   const isPast = outingDate < now;
   
   const mapsUrl = outing.location_details?.maps_url;
+  // Cover image: outing's own image → location photo (no generic placeholder here)
+  const coverImage = (outing as any).cover_image_url || (outing.location_details as any)?.photo_url || null;
   const hasActiveReservations = confirmedReservations.length > 0 || waitlistedReservations.length > 0;
   
   // Check if user is the organizer, co-instructor or admin of this outing
@@ -549,6 +551,16 @@ const OutingDetail = () => {
                 </AlertDialog>
               )}
             </div>
+            {coverImage && (
+              <div className="mb-4 overflow-hidden rounded-xl border border-border/50">
+                <img
+                  src={coverImage}
+                  alt={outing.title}
+                  className="h-48 w-full object-cover sm:h-56"
+                  loading="lazy"
+                />
+              </div>
+            )}
             <h1 className="text-3xl font-bold text-foreground">{outing.title}</h1>
             <div className="mt-4 flex flex-wrap gap-4 text-muted-foreground">
               <div className="flex items-center gap-2">


### PR DESCRIPTION
## Problème

L'image de la sortie s'affichait bien sur la carte (liste) et la page publique `/outing/:id`, mais **pas sur la fiche de gestion** `/outing/:id/manage` (`OutingDetail.tsx`) — celle avec Modifier / Générer le POSS / timeline.

## Correctif

Ajout d'une bannière image en haut de la fiche, juste avant le titre, avec la même priorité que partout ailleurs : **image de la sortie → photo du lieu**. Pas de placeholder générique ici : la bannière n'apparaît que si une vraie image existe.

Frontend uniquement, aucune migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnkGVNwFL7wAsGWyyu7cLp)_