### PR TITLE
feat: garder la bannière et la vignette sur la fiche de sortie

### DIFF
--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -551,6 +551,16 @@ const OutingDetail = () => {
                 </AlertDialog>
               )}
             </div>
+            {coverImage && (
+              <div className="mb-4 overflow-hidden rounded-xl border border-border/50">
+                <img
+                  src={coverImage}
+                  alt={outing.title}
+                  className="h-48 w-full object-cover sm:h-56"
+                  loading="lazy"
+                />
+              </div>
+            )}
             <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:gap-6">
               <div className="min-w-0 lg:flex-1">
             <h1 className="text-3xl font-bold text-foreground">{outing.title}</h1>
@@ -708,7 +718,7 @@ const OutingDetail = () => {
             })()}
               </div>
               {coverImage && (
-                <div className="order-first lg:order-last lg:w-72 xl:w-80 lg:flex-shrink-0">
+                <div className="hidden lg:block lg:w-72 xl:w-80 lg:flex-shrink-0">
                   <img
                     src={coverImage}
                     alt={outing.title}


### PR DESCRIPTION
## Quoi

Sur la fiche `/outing/:id/manage`, on affiche désormais **les deux** :
- la **bannière** pleine largeur en haut,
- **et** la **vignette** à droite des infos (date / timeline / description).

La vignette n'apparaît que sur **grand écran** (`lg+`) : sur mobile la bannière en haut suffit, et empiler deux fois la même image serait redondant.

Frontend uniquement, aucune migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnkGVNwFL7wAsGWyyu7cLp)_