### PR TITLE
Retrait admin d'un participant + notification (tirage au sort sorties bateau)

### DIFF
--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -655,6 +655,28 @@ export const useCancelOuting = () => {
   });
 };
 
+export const useAdminRemoveReservation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ outingId, userId, message }: { outingId: string; userId: string; message?: string }) => {
+      const { error } = await supabase.functions.invoke("send-outing-notification", {
+        body: { outingId, type: "removal", targetUserId: userId, reason: message },
+      });
+
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["outings"] });
+      queryClient.invalidateQueries({ queryKey: ["outing"] });
+      toast.success("Participant retiré et notifié par email");
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Erreur lors du retrait du participant");
+    },
+  });
+};
+
 export const useDeleteOuting = () => {
   const queryClient = useQueryClient();
 

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { format, differenceInHours } from "date-fns";
 import { fr } from "date-fns/locale";
-import { Loader2, MapPin, Calendar, Users, Navigation, Clock, XCircle, Car, UserCheck, AlertTriangle, CloudRain, CheckCircle2, Share2, Copy, Check, Phone, Lock, FileText, Unlock, Shield, ArrowDown, Gauge, Download, Mail, MessageCircle, UserPlus, X, Trash2 } from "lucide-react";
+import { Loader2, MapPin, Calendar, Users, Navigation, Clock, XCircle, Car, UserCheck, AlertTriangle, CloudRain, CheckCircle2, Share2, Copy, Check, Phone, Lock, FileText, Unlock, Shield, ArrowDown, Gauge, Download, Mail, MessageCircle, UserPlus, UserMinus, X, Trash2 } from "lucide-react";
 import Layout from "@/components/layout/Layout";
 import { formatFullName } from "@/lib/formatName";
 
@@ -35,7 +35,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUserRole } from "@/hooks/useUserRole";
-import { useOuting, useUpdateReservationPresence, useUpdateSessionReport, useCancelOuting, useArchiveOuting, useLockPOSS, useUnlockPOSS, useAddCoInstructor, useRemoveCoInstructor, useDeleteOuting } from "@/hooks/useOutings";
+import { useOuting, useUpdateReservationPresence, useUpdateSessionReport, useCancelOuting, useArchiveOuting, useLockPOSS, useUnlockPOSS, useAddCoInstructor, useRemoveCoInstructor, useDeleteOuting, useAdminRemoveReservation } from "@/hooks/useOutings";
 import { usePOSSGenerator } from "@/hooks/usePOSSGenerator";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
@@ -70,6 +70,7 @@ const OutingDetail = () => {
   const updatePresence = useUpdateReservationPresence();
   const updateSessionReport = useUpdateSessionReport();
   const cancelOuting = useCancelOuting();
+  const adminRemoveReservation = useAdminRemoveReservation();
   const deleteOuting = useDeleteOuting();
   const archiveOuting = useArchiveOuting();
   const lockPOSS = useLockPOSS();
@@ -113,6 +114,12 @@ const OutingDetail = () => {
   const [selectedContact, setSelectedContact] = useState<{
     firstName: string; lastName: string; avatarUrl: string | null; email: string | null; phone: string | null;
   } | null>(null);
+  const [participantToRemove, setParticipantToRemove] = useState<{
+    userId: string; name: string;
+  } | null>(null);
+  const [removeMessage, setRemoveMessage] = useState(
+    "Le nombre de demandes pour cette sortie a dépassé le nombre de places disponibles. Un tirage au sort a été effectué et vous n'avez malheureusement pas été retenu(e) cette fois-ci."
+  );
 
   // Compute derived values for the query
   const outingDate = outing ? new Date(outing.date_time) : new Date();
@@ -260,6 +267,8 @@ const OutingDetail = () => {
   const canManageOuting = isOutingOrganizer || isCoInstructor || isAdmin;
   const canEditPresenceAndReport = canManageOuting;
   const canCancelOuting = canManageOuting;
+  // Reservation UPDATE is only allowed by admins or the outing's organizer (RLS), not co-instructors
+  const canRemoveParticipant = isAdmin || isOutingOrganizer;
   
   // Check if outing can be archived (past, not already archived)
   const hasAttendanceMarked = confirmedReservations.some(r => r.is_present);
@@ -271,6 +280,14 @@ const OutingDetail = () => {
 
   const handleCancelOuting = () => {
     cancelOuting.mutate({ outingId: outing.id, reason: cancelReason });
+  };
+
+  const handleRemoveParticipant = () => {
+    if (!participantToRemove) return;
+    adminRemoveReservation.mutate(
+      { outingId: outing.id, userId: participantToRemove.userId, message: removeMessage },
+      { onSuccess: () => setParticipantToRemove(null) }
+    );
   };
 
   const handleArchiveOuting = () => {
@@ -852,22 +869,41 @@ const OutingDetail = () => {
                     </div>
                   </div>
 
-                  {canMarkAttendance && canEditPresenceAndReport && (
-                    <div className="flex items-center gap-2">
-                      <Checkbox
-                        checked={reservation.is_present}
-                        onCheckedChange={(checked) =>
-                          updatePresence.mutate({ reservationId: reservation.id, isPresent: !!checked })
+                  <div className="flex items-center gap-2">
+                    {canMarkAttendance && canEditPresenceAndReport && (
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          checked={reservation.is_present}
+                          onCheckedChange={(checked) =>
+                            updatePresence.mutate({ reservationId: reservation.id, isPresent: !!checked })
+                          }
+                        />
+                        <span className="text-sm text-muted-foreground">Présent</span>
+                      </div>
+                    )}
+                    {canMarkAttendance && !canEditPresenceAndReport && (
+                      <Badge variant={reservation.is_present ? "default" : "outline"} className="text-xs">
+                        {reservation.is_present ? "Présent" : "Absent"}
+                      </Badge>
+                    )}
+                    {!isPast && canRemoveParticipant && !isOrg && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                        title="Retirer ce participant"
+                        onClick={() =>
+                          setParticipantToRemove({
+                            userId: reservation.user_id,
+                            name: formatFullName(profile?.first_name, profile?.last_name),
+                          })
                         }
-                      />
-                      <span className="text-sm text-muted-foreground">Présent</span>
-                    </div>
-                  )}
-                  {canMarkAttendance && !canEditPresenceAndReport && (
-                    <Badge variant={reservation.is_present ? "default" : "outline"} className="text-xs">
-                      {reservation.is_present ? "Présent" : "Absent"}
-                    </Badge>
-                  )}
+                      >
+                        <UserMinus className="h-4 w-4" />
+                      </Button>
+                    )}
+                  </div>
                 </div>
               );
             };
@@ -1168,6 +1204,41 @@ const OutingDetail = () => {
           </Dialog>
         );
       })()}
+
+      {/* Remove participant dialog */}
+      <AlertDialog open={!!participantToRemove} onOpenChange={(open) => !open && setParticipantToRemove(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-destructive" />
+              Retirer {participantToRemove?.name} ?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Sa place sera libérée et il/elle sera notifié(e) par email. Cette action est utile par exemple après un tirage au sort pour retirer les personnes non retenues.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="py-2">
+            <Label htmlFor="removeMessage">Message envoyé au participant</Label>
+            <Textarea
+              id="removeMessage"
+              value={removeMessage}
+              onChange={(e) => setRemoveMessage(e.target.value)}
+              className="mt-2"
+              rows={4}
+            />
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Retour</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRemoveParticipant}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={adminRemoveReservation.isPending}
+            >
+              {adminRemoveReservation.isPending ? "Retrait..." : "Retirer et notifier"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Layout>
   );
 };

--- a/supabase/functions/send-outing-notification/index.ts
+++ b/supabase/functions/send-outing-notification/index.ts
@@ -42,8 +42,9 @@ async function sendEmail(to: string, toName: string, subject: string, html: stri
 
 interface NotificationRequest {
   outingId: string;
-  type: "cancellation" | "reminder";
+  type: "cancellation" | "reminder" | "removal";
   reason?: string;
+  targetUserId?: string;
 }
 
 const handler = async (req: Request): Promise<Response> => {
@@ -82,7 +83,7 @@ const handler = async (req: Request): Promise<Response> => {
 
     console.log(`User ${user.id} attempting notification request`);
 
-    const { outingId, type, reason }: NotificationRequest = await req.json();
+    const { outingId, type, reason, targetUserId }: NotificationRequest = await req.json();
 
     // Use service role for data queries
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
@@ -120,6 +121,81 @@ const handler = async (req: Request): Promise<Response> => {
     }
 
     console.log(`Processing ${type} notification for outing: ${outingId} by user ${user.id}`);
+
+    // Single-participant removal (e.g. not selected in a lottery draw)
+    if (type === "removal") {
+      if (!targetUserId) {
+        return new Response(
+          JSON.stringify({ error: "targetUserId is required for a removal notification" }),
+          { status: 400, headers: { "Content-Type": "application/json", ...corsHeaders } }
+        );
+      }
+
+      const { data: reservation, error: resError } = await supabase
+        .from("reservations")
+        .select(`id, status, profile:profiles(email, first_name, last_name)`)
+        .eq("outing_id", outingId)
+        .eq("user_id", targetUserId)
+        .in("status", ["confirmé", "en_attente"])
+        .maybeSingle();
+
+      if (resError) {
+        console.error("Error fetching reservation:", resError);
+        throw resError;
+      }
+
+      if (!reservation) {
+        return new Response(
+          JSON.stringify({ error: "Réservation active introuvable pour ce participant" }),
+          { status: 404, headers: { "Content-Type": "application/json", ...corsHeaders } }
+        );
+      }
+
+      const { error: updateError } = await supabase
+        .from("reservations")
+        .update({ status: "annulé", cancelled_at: new Date().toISOString() })
+        .eq("id", reservation.id);
+
+      if (updateError) {
+        console.error("Error updating reservation:", updateError);
+        throw updateError;
+      }
+
+      const dateFormattedRemoval = new Date(outing.date_time).toLocaleDateString("fr-FR", {
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+
+      const profile = reservation.profile as any;
+      let emailSent = false;
+      if (profile?.email) {
+        const fullName = `${profile.first_name} ${profile.last_name}`;
+        const subject = `Votre place pour la sortie : ${outing.title}`;
+        const defaultMessage = `Votre place pour la sortie <strong>${outing.title}</strong> prévue le ${dateFormattedRemoval} n'a malheureusement pas pu être maintenue.`;
+        const htmlContent = `
+          <h1>Concernant votre inscription</h1>
+          <p>Bonjour ${profile.first_name},</p>
+          <p>${reason || defaultMessage}</p>
+          <p>Nous espérons vous retrouver lors d'une prochaine sortie !</p>
+          <p>L'équipe Team Oxygen</p>
+        `;
+        try {
+          await sendEmail(profile.email, fullName, subject, htmlContent);
+          emailSent = true;
+        } catch (emailError) {
+          console.error(`Failed to send removal email to ${profile.email}:`, emailError);
+        }
+      }
+
+      return new Response(
+        JSON.stringify({ success: true, notified: emailSent ? 1 : 0 }),
+        { status: 200, headers: { "Content-Type": "application/json", ...corsHeaders } }
+      );
+    }
 
     // Get all reservations with user profiles (confirmed and waitlisted)
     const { data: reservations, error: resError } = await supabase


### PR DESCRIPTION
## Contexte

Nouveau process pour les sorties bateau à places limitées : ouverture de plus de places que prévu, tirage au sort, puis annonce des gagnants. Il fallait un moyen simple de retirer les non-retenus **sans leur demander de se désinscrire**.

## Changements

- **`src/pages/OutingDetail.tsx`** : ajout d'un bouton "retirer" (icône `UserMinus`) sur chaque ligne de participant confirmé, visible pour les admins et l'organisateur de la sortie (pas les co-encadrants, cf. RLS ci-dessous), sur les sorties à venir uniquement. Un clic ouvre une boîte de dialogue de confirmation avec un message email personnalisable (pré-rempli avec un texte adapté au contexte "tirage au sort").
- **`src/hooks/useOutings.ts`** : nouveau hook `useAdminRemoveReservation` qui appelle l'edge function pour annuler la réservation ciblée et notifier la personne.
- **`supabase/functions/send-outing-notification/index.ts`** : nouveau type de notification `"removal"` ciblant un `targetUserId` précis (au lieu de notifier tous les participants). Vérifie que l'appelant est admin ou organisateur de la sortie, annule la réservation de la personne visée et lui envoie un email avec le message saisi par l'admin.

## Pourquoi restreindre aux admins/organisateur (pas les co-encadrants)

Les policies RLS existantes sur `reservations` (`UPDATE`) et le check d'autorisation déjà en place dans `send-outing-notification` n'autorisent que `admin` ou `organizer_id = auth.uid()` — pas les co-encadrants. Le bouton est donc gated en conséquence pour éviter un décalage UI/serveur (un co-encadrant verrait un bouton qui échouerait silencieusement côté serveur).

## Déploiement requis après merge

⚠️ Cette PR modifie une edge function Supabase (`send-outing-notification`). Le merge sur `main` déploie automatiquement le frontend sur Vercel, mais **ne déploie pas** l'edge function — celle-ci doit être déployée séparément sur le projet Supabase pour que la fonctionnalité soit active en production.

## Test plan

- [x] `npm run build` passe sans erreur
- [x] `npm run lint` ne montre aucune nouvelle erreur (les erreurs `no-explicit-any` restantes sont préexistantes dans le fichier)
- [ ] Vérifier en preview/prod qu'un admin/organisateur peut retirer un participant confirmé et que l'email de notification est bien reçu
- [ ] Déployer l'edge function `send-outing-notification` sur Supabase


---
_Generated by [Claude Code](https://claude.ai/code/session_01MZKQgPEfEg5AEo4kzbF8bx)_