### PR TITLE
Badge "Bateau" sur les cartes de sortie

### DIFF
--- a/src/components/outings/OutingCard.tsx
+++ b/src/components/outings/OutingCard.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { Link } from "react-router-dom";
-import { MapPin, Calendar, Users, User, Waves, Droplets, Building, TreePine, Trash2, Clock, Sun, CloudSun, Cloud, Car, Lock, Gauge } from "lucide-react";
+import { MapPin, Calendar, Users, User, Waves, Droplets, Building, TreePine, Trash2, Clock, Sun, CloudSun, Cloud, Car, Lock, Gauge, Ship } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -142,6 +142,12 @@ const OutingCard = ({ outing, carpoolInfo }: OutingCardProps) => {
           {outing.is_staff_only && (
             <Badge className="bg-amber-500 text-white text-xs shadow-lg">
               PRIVÉ STAFF
+            </Badge>
+          )}
+          {outing.dive_mode === "boat" && (
+            <Badge className="bg-sky-700 text-white text-xs shadow-lg gap-1">
+              <Ship className="h-3 w-3" />
+              Bateau
             </Badge>
           )}
           <Badge variant="secondary" className="text-xs shadow-lg">


### PR DESCRIPTION
## Contexte

Les sorties bateau et les sorties du bord (ex. "Sunset côte bleue" vs "Opération mensuelle du vallon") n'étaient pas visuellement différenciées dans la liste "Prochaines sorties".

## Changement

`src/components/outings/OutingCard.tsx` : ajout d'un badge "Bateau" (icône `Ship`) dans le coin supérieur droit de la carte quand `outing.dive_mode === "boat"`. Le champ existait déjà en base (`outings.dive_mode`, renseigné via le formulaire de création "Départ Bateau" / "Départ du Bord") mais n'était affiché nulle part dans la liste.

## Test plan

- [x] `npm run build` passe sans erreur
- [ ] Vérifier visuellement sur une sortie bateau (ex. "Sunset côte bleue") que le badge apparaît, et qu'il n'apparaît pas sur une sortie du bord


---
_Generated by [Claude Code](https://claude.ai/code/session_01MZKQgPEfEg5AEo4kzbF8bx)_