### PR TITLE
Zoom photo des participants sur les sorties

### DIFF
--- a/src/components/participants/ParticipantAvatar.tsx
+++ b/src/components/participants/ParticipantAvatar.tsx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { formatFullName } from "@/lib/formatName";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Shield, Star } from "lucide-react";
+import ParticipantPhotoDialog from "./ParticipantPhotoDialog";
 
 interface ParticipantAvatarProps {
   firstName: string;
@@ -35,44 +37,56 @@ const ParticipantAvatar = ({
   const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
   const fullName = formatFullName(firstName, lastName);
   const isEncadrant = memberStatus === "Encadrant";
+  const [isZoomed, setIsZoomed] = useState(false);
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="relative inline-block">
-            <Avatar className={`${sizeClasses[size]} border-2 ${isOrganizer ? "border-amber-400" : "border-background"} shadow-sm`}>
-              <AvatarImage src={avatarUrl ?? undefined} alt={fullName} />
-              <AvatarFallback className={`text-xs font-medium ${isOrganizer ? "bg-amber-100 text-amber-800" : "bg-primary/10 text-primary"}`}>
-                {initials}
-              </AvatarFallback>
-            </Avatar>
-            {isOrganizer ? (
-              <div
-                className={`absolute ${badgeSizeClasses[size]} flex items-center justify-center rounded-full bg-amber-500 text-white ring-2 ring-background`}
-              >
-                <Star className="h-2 w-2 fill-white" />
-              </div>
-            ) : isEncadrant ? (
-              <div
-                className={`absolute ${badgeSizeClasses[size]} flex items-center justify-center rounded-full bg-amber-500 text-white ring-2 ring-background`}
-              >
-                <Shield className="h-2.5 w-2.5" />
-              </div>
-            ) : null}
-          </div>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p className="font-medium">{fullName}</p>
-          {isOrganizer && (
-            <p className="text-xs text-amber-500">Organisateur</p>
-          )}
-          {isEncadrant && (
-            <p className="text-xs text-amber-500">Encadrant</p>
-          )}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="relative inline-block cursor-pointer focus:outline-none"
+              onClick={() => setIsZoomed(true)}
+            >
+              <Avatar className={`${sizeClasses[size]} border-2 ${isOrganizer ? "border-amber-400" : "border-background"} shadow-sm`}>
+                <AvatarImage src={avatarUrl ?? undefined} alt={fullName} />
+                <AvatarFallback className={`text-xs font-medium ${isOrganizer ? "bg-amber-100 text-amber-800" : "bg-primary/10 text-primary"}`}>
+                  {initials}
+                </AvatarFallback>
+              </Avatar>
+              {isOrganizer ? (
+                <div
+                  className={`absolute ${badgeSizeClasses[size]} flex items-center justify-center rounded-full bg-amber-500 text-white ring-2 ring-background`}
+                >
+                  <Star className="h-2 w-2 fill-white" />
+                </div>
+              ) : isEncadrant ? (
+                <div
+                  className={`absolute ${badgeSizeClasses[size]} flex items-center justify-center rounded-full bg-amber-500 text-white ring-2 ring-background`}
+                >
+                  <Shield className="h-2.5 w-2.5" />
+                </div>
+              ) : null}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="font-medium">{fullName}</p>
+            {isOrganizer && (
+              <p className="text-xs text-amber-500">Organisateur</p>
+            )}
+            {isEncadrant && (
+              <p className="text-xs text-amber-500">Encadrant</p>
+            )}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+
+      <ParticipantPhotoDialog
+        participant={isZoomed ? { firstName, lastName, avatarUrl } : null}
+        onClose={() => setIsZoomed(false)}
+      />
+    </>
   );
 };
 

--- a/src/components/participants/ParticipantPhotoDialog.tsx
+++ b/src/components/participants/ParticipantPhotoDialog.tsx
@@ -1,0 +1,44 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+interface ParticipantPhotoDialogProps {
+  participant: {
+    firstName: string;
+    lastName: string;
+    avatarUrl?: string | null;
+  } | null;
+  onClose: () => void;
+}
+
+const ParticipantPhotoDialog = ({ participant, onClose }: ParticipantPhotoDialogProps) => {
+  if (!participant) return null;
+  const initials = `${participant.firstName.charAt(0)}${participant.lastName.charAt(0)}`.toUpperCase();
+
+  return (
+    <Dialog open={!!participant} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-xs">
+        <DialogHeader>
+          <div className="flex flex-col items-center gap-3 pt-2">
+            <Avatar className="h-36 w-36">
+              {participant.avatarUrl && (
+                <AvatarImage
+                  src={participant.avatarUrl}
+                  alt={`${participant.firstName} ${participant.lastName}`}
+                />
+              )}
+              <AvatarFallback className="bg-primary/10 text-primary font-bold text-3xl">
+                {initials}
+              </AvatarFallback>
+            </Avatar>
+            <DialogTitle className="text-center leading-tight">
+              <p className="font-semibold">{participant.firstName}</p>
+              <p className="text-sm font-normal text-muted-foreground">{participant.lastName}</p>
+            </DialogTitle>
+          </div>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ParticipantPhotoDialog;

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -1161,18 +1161,18 @@ const OutingDetail = () => {
           <Dialog open={!!selectedContact} onOpenChange={(open) => !open && setSelectedContact(null)}>
             <DialogContent className="sm:max-w-xs">
               <DialogHeader>
-                <DialogTitle className="flex items-center gap-3">
-                  <Avatar className="h-10 w-10">
+                <div className="flex flex-col items-center gap-3 pt-2">
+                  <Avatar className="h-36 w-36">
                     {selectedContact.avatarUrl && <AvatarImage src={selectedContact.avatarUrl} />}
-                    <AvatarFallback className="bg-primary/10 text-primary font-semibold">
+                    <AvatarFallback className="bg-primary/10 text-primary font-bold text-3xl">
                       {selectedContact.firstName.charAt(0)}{selectedContact.lastName.charAt(0)}
                     </AvatarFallback>
                   </Avatar>
-                  <div className="text-left leading-tight">
+                  <DialogTitle className="text-center leading-tight">
                     <p className="font-semibold">{selectedContact.firstName}</p>
                     <p className="text-sm font-normal text-muted-foreground">{selectedContact.lastName}</p>
-                  </div>
-                </DialogTitle>
+                  </DialogTitle>
+                </div>
               </DialogHeader>
               <div className="flex gap-3 pt-2 justify-center">
                 {selectedContact.email && (

--- a/src/pages/OutingView.tsx
+++ b/src/pages/OutingView.tsx
@@ -62,6 +62,7 @@ import { useViewMode } from "@/contexts/ViewModeContext";
 
 import CarpoolSection from "@/components/carpool/CarpoolSection";
 import { useCarpools } from "@/hooks/useCarpools";
+import ParticipantPhotoDialog from "@/components/participants/ParticipantPhotoDialog";
 
 /** Extract max depth from prerogatives string, e.g. "-40m / 80m dynamique" -> "-40m" */
 const extractDepth = (prerogatives: string | null): string | null => {
@@ -123,6 +124,9 @@ const OutingView = () => {
   const [showCarpoolEdit, setShowCarpoolEdit] = useState(false);
   const [editCarpoolOption, setEditCarpoolOption] = useState<CarpoolOption>("none");
   const [editCarpoolSeats, setEditCarpoolSeats] = useState(1);
+  const [zoomedParticipant, setZoomedParticipant] = useState<{
+    firstName: string; lastName: string; avatarUrl: string | null;
+  } | null>(null);
 
   const handleCarpoolOptionChange = (value: CarpoolOption) => {
     setCarpoolOption(value);
@@ -659,8 +663,16 @@ const OutingView = () => {
                             : "border-border bg-muted/30"
                         }`}
                       >
-                        <div className="relative">
-                          <Avatar className="h-10 w-10">
+                        <button
+                          type="button"
+                          className="relative focus:outline-none"
+                          onClick={() => profile && setZoomedParticipant({
+                            firstName: profile.first_name ?? "",
+                            lastName: profile.last_name ?? "",
+                            avatarUrl: profile.avatar_url ?? null,
+                          })}
+                        >
+                          <Avatar className="h-10 w-10 transition-opacity hover:opacity-80">
                             <AvatarImage src={profile?.avatar_url ?? undefined} />
                             <AvatarFallback className={`text-sm ${isOrg || isCoInstr ? "bg-amber-200 text-amber-800" : "bg-primary/10 text-primary"}`}>
                               {initials}
@@ -671,7 +683,7 @@ const OutingView = () => {
                               <Shield className="h-3 w-3 text-white" />
                             </div>
                           )}
-                        </div>
+                        </button>
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2">
                             <p className="font-medium text-foreground truncate">
@@ -805,6 +817,11 @@ const OutingView = () => {
           )}
         </div>
       </section>
+
+      <ParticipantPhotoDialog
+        participant={zoomedParticipant}
+        onClose={() => setZoomedParticipant(null)}
+      />
     </Layout>
   );
 };


### PR DESCRIPTION
## Summary
- Les vignettes de participants étant petites sur les pages de sortie, un clic sur une photo ouvre désormais un dialog avec la photo agrandie (dans le même esprit que le trombinoscope).
- Nouveau composant réutilisable `ParticipantPhotoDialog` (avatar 144px + nom, style repris du trombinoscope).
- `ParticipantAvatar` (utilisé sur la page "Mes réservations") déclenche ce zoom au clic, en plus de l'infobulle existante.
- `OutingView` (page sortie vue par un membre) : les vignettes participants sont désormais cliquables et ouvrent le zoom.
- `OutingDetail` (page de gestion de sortie) : la fiche contact existante réutilise maintenant le même format de photo agrandie (144px, centrée) au lieu du petit avatar (40px) précédent.

## Test plan
- [x] `npm run build`
- [x] `npx eslint` sur les fichiers modifiés (aucune nouvelle erreur)
- [ ] Vérifier visuellement sur la preview Vercel : cliquer sur une vignette participant dans "Mes réservations", sur la page d'une sortie, et dans la fiche contact de la page de gestion.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KYZGA6QoyGenBB6hCJEkqb)_