### PR TITLE
Agrandir la photo zoomée des participants sur mobile

### DIFF
--- a/src/components/participants/ParticipantPhotoDialog.tsx
+++ b/src/components/participants/ParticipantPhotoDialog.tsx
@@ -1,5 +1,5 @@
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import ParticipantPhotoFrame from "./ParticipantPhotoFrame";
 
 interface ParticipantPhotoDialogProps {
   participant: {
@@ -12,24 +12,17 @@ interface ParticipantPhotoDialogProps {
 
 const ParticipantPhotoDialog = ({ participant, onClose }: ParticipantPhotoDialogProps) => {
   if (!participant) return null;
-  const initials = `${participant.firstName.charAt(0)}${participant.lastName.charAt(0)}`.toUpperCase();
 
   return (
     <Dialog open={!!participant} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="sm:max-w-xs">
+      <DialogContent className="sm:max-w-sm">
         <DialogHeader>
           <div className="flex flex-col items-center gap-3 pt-2">
-            <Avatar className="h-36 w-36">
-              {participant.avatarUrl && (
-                <AvatarImage
-                  src={participant.avatarUrl}
-                  alt={`${participant.firstName} ${participant.lastName}`}
-                />
-              )}
-              <AvatarFallback className="bg-primary/10 text-primary font-bold text-3xl">
-                {initials}
-              </AvatarFallback>
-            </Avatar>
+            <ParticipantPhotoFrame
+              firstName={participant.firstName}
+              lastName={participant.lastName}
+              avatarUrl={participant.avatarUrl}
+            />
             <DialogTitle className="text-center leading-tight">
               <p className="font-semibold">{participant.firstName}</p>
               <p className="text-sm font-normal text-muted-foreground">{participant.lastName}</p>

--- a/src/components/participants/ParticipantPhotoFrame.tsx
+++ b/src/components/participants/ParticipantPhotoFrame.tsx
@@ -1,0 +1,27 @@
+interface ParticipantPhotoFrameProps {
+  firstName: string;
+  lastName: string;
+  avatarUrl?: string | null;
+}
+
+const ParticipantPhotoFrame = ({ firstName, lastName, avatarUrl }: ParticipantPhotoFrameProps) => {
+  const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+
+  return (
+    <div className="w-full aspect-[4/5] overflow-hidden rounded-2xl bg-primary/10">
+      {avatarUrl ? (
+        <img
+          src={avatarUrl}
+          alt={`${firstName} ${lastName}`}
+          className="h-full w-full object-cover"
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center">
+          <span className="text-5xl font-bold text-primary">{initials}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ParticipantPhotoFrame;

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -40,6 +40,7 @@ import { usePOSSGenerator } from "@/hooks/usePOSSGenerator";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import EmergencySOSModal from "@/components/emergency/EmergencySOSModal";
+import ParticipantPhotoFrame from "@/components/participants/ParticipantPhotoFrame";
 import { FicheEvacuationGenerator } from "@/components/pdf/FicheEvacuationGenerator";
 import { supabase } from "@/integrations/supabase/client";
 import { useQuery } from "@tanstack/react-query";
@@ -1159,15 +1160,14 @@ const OutingDetail = () => {
         const phone = selectedContact.phone ? normalizePhone(selectedContact.phone) : null;
         return (
           <Dialog open={!!selectedContact} onOpenChange={(open) => !open && setSelectedContact(null)}>
-            <DialogContent className="sm:max-w-xs">
+            <DialogContent className="sm:max-w-sm">
               <DialogHeader>
                 <div className="flex flex-col items-center gap-3 pt-2">
-                  <Avatar className="h-36 w-36">
-                    {selectedContact.avatarUrl && <AvatarImage src={selectedContact.avatarUrl} />}
-                    <AvatarFallback className="bg-primary/10 text-primary font-bold text-3xl">
-                      {selectedContact.firstName.charAt(0)}{selectedContact.lastName.charAt(0)}
-                    </AvatarFallback>
-                  </Avatar>
+                  <ParticipantPhotoFrame
+                    firstName={selectedContact.firstName}
+                    lastName={selectedContact.lastName}
+                    avatarUrl={selectedContact.avatarUrl}
+                  />
                   <DialogTitle className="text-center leading-tight">
                     <p className="font-semibold">{selectedContact.firstName}</p>
                     <p className="text-sm font-normal text-muted-foreground">{selectedContact.lastName}</p>

--- a/src/pages/Trombinoscope.tsx
+++ b/src/pages/Trombinoscope.tsx
@@ -15,6 +15,7 @@ import { Users, Crown, GraduationCap, UserCircle, Mail, Phone, MessageCircle, Se
 import { Input } from "@/components/ui/input";
 import { formatFirstName, formatLastName } from "@/lib/formatName";
 import { getFishLevel, FISH_LEVELS } from "@/hooks/useTrombinoscope";
+import ParticipantPhotoFrame from "@/components/participants/ParticipantPhotoFrame";
 
 // Generate a pastel color from initials
 const getAvatarColor = (name: string): string => {
@@ -59,15 +60,14 @@ const ContactDialog = ({ member, onClose }: ContactDialogProps) => {
 
   return (
     <Dialog open={!!member} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="sm:max-w-xs">
+      <DialogContent className="sm:max-w-sm">
         <DialogHeader>
           <div className="flex flex-col items-center gap-3 pt-2">
-            <Avatar className="h-36 w-36">
-              {member.avatar_url && <AvatarImage src={member.avatar_url} alt={`${member.first_name} ${member.last_name}`} />}
-              <AvatarFallback className={`${getAvatarColor(member.first_name + member.last_name)} text-foreground font-bold text-3xl`}>
-                {getInitials(member.first_name, member.last_name)}
-              </AvatarFallback>
-            </Avatar>
+            <ParticipantPhotoFrame
+              firstName={member.first_name}
+              lastName={member.last_name}
+              avatarUrl={member.avatar_url}
+            />
             <DialogTitle className="text-center leading-tight">
               <p className="font-semibold">{formatFirstName(member.first_name)}</p>
               <p className="text-sm font-normal text-muted-foreground">{formatLastName(member.last_name)}</p>


### PR DESCRIPTION
## Summary
- Le zoom photo ajouté précédemment (PR #212) affichait un cercle fixe de 144px — trop petit sur mobile et inadapté aux photos au format portrait ("allongé"), qui étaient rognées en carré.
- Nouveau composant `ParticipantPhotoFrame` : vignette rectangulaire (ratio 4:5, coins arrondis) qui occupe toute la largeur disponible du dialog au lieu d'un petit cercle fixe — beaucoup plus grande sur mobile où le dialog est déjà en pleine largeur.
- Appliqué de façon cohérente aux 3 endroits où le zoom photo participant existe : page de sortie (`OutingView`/`ParticipantPhotoDialog`), fiche contact de la page de gestion (`OutingDetail`), et fiche contact du trombinoscope (`Trombinoscope`).
- Largeur max du dialog légèrement augmentée (`sm:max-w-xs` → `sm:max-w-sm`) pour laisser plus de place à la photo sur desktop.

## Test plan
- [x] `npm run build`
- [x] `npx eslint` sur les fichiers modifiés (aucune nouvelle erreur)
- [ ] Vérifier visuellement sur la preview Vercel, sur mobile : la photo zoomée doit remplir la largeur de l'écran avec un format portrait plutôt qu'un petit cercle.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KYZGA6QoyGenBB6hCJEkqb)_