### PR TITLE
fix: le trigger DWH waypoints empêchait la suppression des points d'intérêt

### DIFF
--- a/supabase/migrations/20260707120000_fix_dwh_waypoints_delete.sql
+++ b/supabase/migrations/20260707120000_fix_dwh_waypoints_delete.sql
@@ -1,0 +1,26 @@
+-- Fix DWH sync: trg_dwh_waypoints se déclenche aussi sur DELETE, mais la fonction
+-- faisait toujours un INSERT avec NEW.id (NULL sur DELETE), ce qui violait la
+-- contrainte NOT NULL de dim_waypoint.waypoint_id et empêchait toute suppression
+-- de point d'intérêt (parking, entrée/sortie, etc.) sur les lieux de plongée.
+
+CREATE OR REPLACE FUNCTION public.dwh_sync_dim_waypoint()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    DELETE FROM dim_waypoint WHERE waypoint_id = OLD.id;
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO dim_waypoint (waypoint_id, site_id, nom, latitude, longitude, type_point)
+  VALUES (NEW.id, NEW.site_id, NEW.name, NEW.latitude, NEW.longitude, NEW.point_type::text)
+  ON CONFLICT (waypoint_id) DO UPDATE SET
+    nom = EXCLUDED.nom, latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude, type_point = EXCLUDED.type_point,
+    updated_at = now();
+  RETURN NEW;
+END;
+$function$;


### PR DESCRIPTION
## Résumé

- Corrige `dwh_sync_dim_waypoint()` : le trigger `trg_dwh_waypoints` se déclenche sur `INSERT OR UPDATE OR DELETE`, mais la fonction faisait toujours un `INSERT ... VALUES (NEW.id, ...)`. Sur `DELETE`, `NEW` est `NULL`, donc `NEW.id` était `NULL`, ce qui violait la contrainte `NOT NULL` de `dim_waypoint.waypoint_id` et bloquait toute suppression de point d'intérêt (parking, entrée/sortie, etc.) sur les lieux de plongée.
- La fonction gère maintenant explicitement `TG_OP = 'DELETE'` en supprimant la ligne correspondante de `dim_waypoint` via `OLD.id`, au lieu de tenter un insert.
- Le correctif a déjà été appliqué directement sur la base de production (via Supabase MCP) pour débloquer la suppression immédiatement ; cette PR ajoute la migration correspondante au dépôt pour garder l'historique du schéma synchronisé.

## Test plan

- [x] Vérifié via SQL que la fonction déployée contient bien la branche `DELETE`
- [ ] Confirmer dans l'app qu'un point d'intérêt (ex: "Parking") peut être supprimé sans l'erreur `null value in column "waypoint_id"`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk4Mo2Czfn6tAdFEDgabgi)_