### PR TITLE
feat: afficher "Mes Sorties" dans la nav principale

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -45,17 +45,24 @@ const Header = () => {
     const items = [
       { to: "/", label: "Sorties", icon: Waves },
       { to: "/reservations", label: "Mes Réservations", icon: Calendar },
+    ];
+
+    if (effectiveIsOrganizer) {
+      items.push({ to: "/mes-sorties", label: "Mes Sorties", icon: FileText });
+    }
+
+    items.push(
       { to: "/map", label: "Carte", icon: MapIcon },
       { to: "/weather", label: "Météo", icon: CloudSun },
       { to: "/trombinoscope", label: "Trombi", icon: Users },
-    ];
+    );
 
     if (isAdmin) {
       items.push({ to: "/admin", label: "Administration", icon: Settings });
     }
 
     return items;
-  }, [isAdmin]);
+  }, [isAdmin, effectiveIsOrganizer]);
 
   // Entrées regroupées dans le menu « Plus »
   const moreItems = useMemo(() => {
@@ -75,7 +82,6 @@ const Header = () => {
     }
 
     if (effectiveIsOrganizer) {
-      items.push({ to: "/mes-sorties", label: "Mes Sorties", icon: Calendar });
       items.push({ to: "/archives", label: "Archives", icon: FileText });
     }
 


### PR DESCRIPTION
## Résumé

- Pour les encadrants/organisateurs, l'entrée "Mes Sorties" était reléguée dans le menu "Plus" du header.
- Elle apparaît maintenant directement dans la barre de navigation principale (desktop et mobile), positionnée juste après "Mes Réservations", comme demandé.
- Aucun changement pour les membres non-organisateurs (l'entrée ne s'affiche que si `effectiveIsOrganizer` est vrai, comme avant).

## Test plan

- [x] `npm run build` passe
- [x] `npx eslint src/components/layout/Header.tsx` sans erreur
- [ ] Vérifier visuellement dans la preview Vercel avec un compte encadrant/organisateur que "Mes Sorties" apparaît bien juste après "Mes Réservations" dans la nav


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk4Mo2Czfn6tAdFEDgabgi)_