### PR TITLE
fix: aligner la profondeur max du POSS sur la table Niveaux d'Apnée + phrase EAO/EAA

### DIFF
--- a/src/components/poss/POSSGenerator.ts
+++ b/src/components/poss/POSSGenerator.ts
@@ -3,6 +3,7 @@ import autoTable from "jspdf-autotable";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { Waypoint, getWaypointLabel } from "@/hooks/useWaypoints";
+import { OutingType } from "@/hooks/useOutings";
 import logoTeamOxygen from "@/assets/logo-team-oxygen-transparent.png";
 
 // Types for POSS generation
@@ -53,6 +54,7 @@ export interface POSSData {
   outingTitle: string;
   outingDateTime: string;
   outingLocation: string;
+  outingType: OutingType;
   diveMode: "boat" | "shore" | null;
   location: POSSLocation | null;
   boat: POSSBoat | null;
@@ -60,6 +62,9 @@ export interface POSSData {
   participants: POSSParticipant[];
   organizerName: string;
   organizerLevel: string | null;
+  organizerLevelName: string | null;
+  organizerMaxDepthEaa: number | null;
+  organizerMaxDepthEao: number | null;
   organizerPhone: string | null;
   coInstructors: POSSCoInstructor[];
   waterEntryTime: string | null;
@@ -145,26 +150,6 @@ const formatPhone = (raw: string | null | undefined): string => {
   return frenchPhoneGroups(digits);
 };
 
-// Helper: Get max depth based on instructor level (FSGT)
-const getMaxDepthForLevel = (apneaLevel: string | null): number | null => {
-  if (!apneaLevel) return null;
-
-  const level = apneaLevel.toUpperCase().trim();
-
-  // FSGT levels - profondeur max autorisée pour l'encadrement
-  if (level.includes("EA1")) return 6;
-  if (level.includes("EA2")) return 15;  // ⚠️ EA2 = 15m (pas 20m)
-  if (level.includes("EA3")) return 40;
-  if (level.includes("EA4")) return 60;
-
-  // FFESSM levels (if needed)
-  if (level.includes("E1")) return 20;
-  if (level.includes("E2")) return 40;
-  if (level.includes("E3") || level.includes("E4")) return 60;
-
-  return null;
-};
-
 // Helper: Calculate session duration
 const calculateDuration = (entryTime: string | null, exitTime: string | null): string => {
   if (!entryTime || !exitTime) return "N/A";
@@ -189,7 +174,7 @@ const calculateDuration = (entryTime: string | null, exitTime: string | null): s
 
 // Main POSS Generator
 export const generatePOSS = async (data: POSSData): Promise<void> => {
-  const { outingTitle, outingDateTime, outingLocation, diveMode, location, boat, waypoints, participants, organizerName, organizerLevel, organizerPhone, coInstructors, waterEntryTime, waterExitTime, weather } = data;
+  const { outingTitle, outingDateTime, outingLocation, outingType, diveMode, location, boat, waypoints, participants, organizerName, organizerLevel, organizerLevelName, organizerMaxDepthEaa, organizerMaxDepthEao, organizerPhone, coInstructors, waterEntryTime, waterExitTime, weather } = data;
   
   const doc = new jsPDF({
     orientation: "landscape",
@@ -315,8 +300,19 @@ export const generatePOSS = async (data: POSSData): Promise<void> => {
   // ====================
   // URGENCE + PROFONDEUR MAX - MISE EN ÉVIDENCE
   // ====================
-  const maxDepth = getMaxDepthForLevel(organizerLevel);
-  const maxDepthStr = maxDepth ? `${maxDepth}m` : "N/A";
+  // Profondeur max encadrée = limite du niveau du DP (apnea_levels), croisée avec
+  // la profondeur max du site si elle est plus restrictive. Même logique que sur
+  // les cartes de sortie et la fiche détaillée (OutingCard / OutingDetail).
+  const isOpenWater = outingType === "Mer" || outingType === "Étang" || outingType === "Dépollution";
+  const organizerMaxDepth = isOpenWater ? organizerMaxDepthEao : organizerMaxDepthEaa;
+  const locationMaxDepth = location?.max_depth ?? null;
+  const effectiveMaxDepth = organizerMaxDepth && locationMaxDepth
+    ? Math.min(organizerMaxDepth, locationMaxDepth)
+    : organizerMaxDepth || locationMaxDepth;
+  const maxDepthStr = effectiveMaxDepth ? `${effectiveMaxDepth}m` : "N/A";
+  const encadrementLabel = isOpenWater ? "EAO" : "EAA";
+  const levelLabel = organizerLevelName || organizerLevel || "encadrant";
+
   const bandHeight = 9;
   const halfWidth = (contentWidth - 4) / 2;
 
@@ -329,10 +325,23 @@ export const generatePOSS = async (data: POSSData): Promise<void> => {
 
   // Profondeur max (droite)
   drawBox(doc, margin + halfWidth + 4, y, halfWidth, bandHeight, { fill: "#fee2e2", stroke: "#dc2626", lineWidth: 1.2 });
-  doc.text(`PROFONDEUR MAX (${organizerLevel || "encadrant"}) : ${maxDepthStr}`, margin + halfWidth + 4 + halfWidth / 2, y + 6, { align: "center" });
+  doc.text(`PROFONDEUR MAX (${levelLabel}) : ${maxDepthStr}`, margin + halfWidth + 4 + halfWidth / 2, y + 6, { align: "center" });
   doc.setTextColor("#000000");
 
-  y += bandHeight + 4;
+  y += bandHeight + 3;
+
+  if (effectiveMaxDepth) {
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(7.5);
+    doc.setTextColor("#666666");
+    const noticeText = `Les apnéistes peuvent avoir des prérogatives personnelles plus profondes, mais dans le cadre d'une activité organisée par le club avec un DP « ${levelLabel} », la zone encadrée doit rester dans la limite ${encadrementLabel} de ${effectiveMaxDepth} m.`;
+    const noticeLines = doc.splitTextToSize(noticeText, contentWidth);
+    doc.text(noticeLines, margin, y + 2.5);
+    y += noticeLines.length * 3 + 3;
+    doc.setTextColor("#000000");
+  }
+
+  y += 1;
 
   // ====================
   // B. CARTOGRAPHIE OPÉRATIONNELLE

--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -97,7 +97,7 @@ export interface Outing {
 // Résout le niveau d'apnée courant (saison en cours) d'un ensemble d'utilisateurs
 // via membership_yearly_status (source de vérité), avec repli sur profiles.apnea_level
 // si l'utilisateur n'a pas de statut de saison enregistré.
-async function resolveCurrentSeasonApneaLevels(
+export async function resolveCurrentSeasonApneaLevels(
   userIds: (string | null | undefined)[]
 ): Promise<Map<string, string | null>> {
   const uniqueIds = [...new Set(userIds.filter((id): id is string => !!id))];

--- a/src/hooks/usePOSSGenerator.ts
+++ b/src/hooks/usePOSSGenerator.ts
@@ -1,5 +1,5 @@
 import { supabase } from "@/integrations/supabase/client";
-import { Outing } from "@/hooks/useOutings";
+import { Outing, resolveCurrentSeasonApneaLevels } from "@/hooks/useOutings";
 import { Waypoint } from "@/hooks/useWaypoints";
 import { generatePOSS, POSSData, POSSParticipant, POSSLocation, POSSBoat } from "@/components/poss/POSSGenerator";
 import { toast } from "sonner";
@@ -33,40 +33,34 @@ export const usePOSSGenerator = () => {
       const confirmedReservations = outing.reservations?.filter(r => r.status === "confirmé") || [];
       const participants: POSSParticipant[] = [];
 
-      // Get organizer's profile to fetch their apnea level and personal phone
+      // Get organizer's phone, current-season apnea level and encadrement depth limits
       let organizerApneaLevel: string | null = null;
+      let organizerLevelName: string | null = null;
+      let organizerMaxDepthEaa: number | null = null;
+      let organizerMaxDepthEao: number | null = null;
       let organizerPhone: string | null = null;
       if (outing.organizer_id) {
         const { data: organizerProfile } = await supabase
           .from("profiles")
-          .select("email, apnea_level, phone")
+          .select("phone")
           .eq("id", outing.organizer_id)
           .single();
+        organizerPhone = organizerProfile?.phone || null;
 
-        if (organizerProfile) {
-          organizerPhone = organizerProfile.phone || null;
-          // Try to get the most current apnea level from membership_yearly_status
-          const { data: organizerDirectory } = await supabase
-            .from("club_members_directory")
-            .select("id")
-            .eq("email", organizerProfile.email.toLowerCase())
-            .single();
+        const seasonLevels = await resolveCurrentSeasonApneaLevels([outing.organizer_id]);
+        organizerApneaLevel = seasonLevels.get(outing.organizer_id) || null;
 
-          if (organizerDirectory) {
-            const currentSeasonYear = new Date().getMonth() >= 8
-              ? new Date().getFullYear() + 1
-              : new Date().getFullYear();
+        if (organizerApneaLevel) {
+          const { data: levelData } = await supabase
+            .from("apnea_levels")
+            .select("name, profondeur_max_eaa, profondeur_max_eao")
+            .eq("code", organizerApneaLevel)
+            .maybeSingle();
 
-            const { data: organizerStatus } = await supabase
-              .from("membership_yearly_status")
-              .select("apnea_level")
-              .eq("member_id", organizerDirectory.id)
-              .eq("season_year", currentSeasonYear)
-              .single();
-
-            organizerApneaLevel = organizerStatus?.apnea_level || organizerProfile.apnea_level;
-          } else {
-            organizerApneaLevel = organizerProfile.apnea_level;
+          if (levelData) {
+            organizerLevelName = levelData.name;
+            organizerMaxDepthEaa = levelData.profondeur_max_eaa;
+            organizerMaxDepthEao = levelData.profondeur_max_eao;
           }
         }
       }
@@ -170,6 +164,7 @@ export const usePOSSGenerator = () => {
         outingTitle: outing.title,
         outingDateTime: outing.date_time,
         outingLocation: outing.location,
+        outingType: outing.outing_type,
         diveMode: outing.dive_mode || null,
         location: locationData,
         boat: boatData,
@@ -177,6 +172,9 @@ export const usePOSSGenerator = () => {
         participants,
         organizerName,
         organizerLevel: organizerApneaLevel,
+        organizerLevelName,
+        organizerMaxDepthEaa,
+        organizerMaxDepthEao,
         organizerPhone,
         coInstructors,
         waterEntryTime: outing.water_entry_time || null,


### PR DESCRIPTION
## Résumé

Suite à #216 (badge "Profondeur max" sur les cartes/fiche de sortie), le générateur de fiche POSS avait son propre barème de profondeurs codé en dur (`getMaxDepthForLevel`), différent de la table de référence `apnea_levels` (Administration → Niveaux d'Apnée). Résultat : la profondeur affichée sur le POSS pouvait ne pas correspondre à celle affichée sur la sortie.

- Le générateur POSS résout maintenant le niveau du DP via le même helper que les sorties (`resolveCurrentSeasonApneaLevels`, saison en cours dans `membership_yearly_status`) et va chercher sa profondeur max dans `apnea_levels` — une seule source de vérité, configurable dans Administration → Niveaux d'Apnée.
- La profondeur effective tient compte de EAO (mer/étang/dépollution) vs EAA (piscine/fosse), et prend le minimum avec la profondeur max du site si celle-ci est plus restrictive — même logique que sur les cartes de sortie et la fiche détaillée.
- Ajout sur la **première page** du POSS, sous le bandeau "PROFONDEUR MAX", de la phrase :
  > Les apnéistes peuvent avoir des prérogatives personnelles plus profondes, mais dans le cadre d'une activité organisée par le club avec un DP « EA2 », la zone encadrée doit rester dans la limite EAO de 15 m.
  Le niveau du DP et la profondeur restent dynamiques.

## Test plan

- [x] `npm run build` passe
- [x] `npx eslint` sur les fichiers modifiés — pas de nouvelle erreur au-delà du style déjà présent
- [x] Généré un POSS de test en local (DP niveau EA2, sortie en mer) : le bandeau affiche bien "PROFONDEUR MAX (EA2) : 15m" et la phrase complète apparaît juste dessous sur la première page
- [ ] Vérifier sur la preview Vercel en générant un vrai POSS depuis une sortie existante


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk4Mo2Czfn6tAdFEDgabgi)_