### PR TITLE
feat: proposer plusieurs motifs d'annulation de sortie (pas que la météo)

### DIFF
--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -53,6 +53,14 @@ import SatelliteMiniMap from "@/components/locations/SatelliteMiniMap";
 import { Anchor, Satellite } from "lucide-react";
 import { useApneaLevels, type ApneaLevel } from "@/hooks/useApneaLevels";
 
+/** Motifs d'annulation proposés en un clic (le champ reste éditable pour un motif libre) */
+const CANCEL_REASONS = [
+  "Météo défavorable",
+  "Nombre d'inscrits insuffisant",
+  "Encadrant indisponible",
+  "Problème logistique",
+];
+
 /** Extract max depth from prerogatives string */
 const extractDepth = (prerogatives: string | null): string | null => {
   if (!prerogatives) return null;
@@ -547,12 +555,25 @@ const OutingDetail = () => {
                     </AlertDialogHeader>
                     <div className="py-4">
                       <Label htmlFor="cancelReason">Motif d'annulation</Label>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {CANCEL_REASONS.map((reason) => (
+                          <Button
+                            key={reason}
+                            type="button"
+                            variant={cancelReason === reason ? "default" : "outline"}
+                            size="sm"
+                            onClick={() => setCancelReason(reason)}
+                          >
+                            {reason}
+                          </Button>
+                        ))}
+                      </div>
                       <Input
                         id="cancelReason"
                         value={cancelReason}
                         onChange={(e) => setCancelReason(e.target.value)}
-                        placeholder="Météo défavorable, autre..."
-                        className="mt-2"
+                        placeholder="Météo défavorable, nombre d'inscrits insuffisant, autre..."
+                        className="mt-3"
                       />
                     </div>
                     <AlertDialogFooter>


### PR DESCRIPTION
## Contexte

Lors de l'annulation d'une sortie, seul un champ libre pré-rempli avec « Météo défavorable » était proposé. Or la météo n'est pas le seul motif d'annulation : le **nombre d'inscrits insuffisant** en est un fréquent, ainsi que l'indisponibilité d'un encadrant ou un problème logistique.

## Changement

- Ajout de motifs prédéfinis sélectionnables en un clic dans la boîte de dialogue « Annuler la sortie » :
  - Météo défavorable
  - Nombre d'inscrits insuffisant
  - Encadrant indisponible
  - Problème logistique
- Le champ texte reste **entièrement éditable** pour saisir un motif libre.
- Le motif choisi est envoyé tel quel dans l'email de notification aux inscrits (aucun changement backend nécessaire).

## Test

- `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzojHK5RnAHbk3UGCprZjV)_