### PR TITLE
feat: adapter le corps du mail d'annulation selon le motif

### DIFF
--- a/supabase/functions/send-outing-notification/index.ts
+++ b/supabase/functions/send-outing-notification/index.ts
@@ -47,6 +47,33 @@ interface NotificationRequest {
   targetUserId?: string;
 }
 
+/**
+ * Adapte le corps du mail d'annulation au motif choisi par l'organisateur.
+ * Renvoie le HTML des paragraphes situés entre la salutation et la formule de fin.
+ * Les motifs connus donnent un message dédié ; un motif libre garde une phrase
+ * générique suivie d'une ligne « Motif : … ».
+ */
+function buildCancellationBody(reason: string | undefined, title: string, dateFormatted: string): string {
+  const outingRef = `la sortie <strong>${title}</strong> prévue le ${dateFormatted}`;
+  const normalized = (reason ?? "").trim().toLowerCase();
+
+  switch (normalized) {
+    case "météo défavorable":
+      return `<p>Nous sommes au regret de vous informer que ${outingRef} est annulée en raison de conditions météo défavorables. La sécurité de tous reste notre priorité.</p>`;
+    case "nombre d'inscrits insuffisant":
+      return `<p>Nous sommes au regret de vous informer que ${outingRef} est annulée faute d'un nombre suffisant d'inscrits pour la maintenir dans de bonnes conditions.</p>`;
+    case "encadrant indisponible":
+      return `<p>Nous sommes au regret de vous informer que ${outingRef} est annulée en raison de l'indisponibilité de l'encadrant.</p>`;
+    case "problème logistique":
+      return `<p>Nous sommes au regret de vous informer que ${outingRef} est annulée pour un problème logistique.</p>`;
+    default: {
+      const base = `<p>Nous sommes au regret de vous informer que ${outingRef} a été annulée.</p>`;
+      const motif = reason?.trim() ? `<p><strong>Motif :</strong> ${reason.trim()}</p>` : "";
+      return base + motif;
+    }
+  }
+}
+
 const handler = async (req: Request): Promise<Response> => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
@@ -238,8 +265,7 @@ const handler = async (req: Request): Promise<Response> => {
         ? `
           <h1>Sortie annulée</h1>
           <p>Bonjour ${profile.first_name},</p>
-          <p>Nous sommes au regret de vous informer que la sortie <strong>${outing.title}</strong> prévue le ${dateFormatted} a été annulée.</p>
-          ${reason ? `<p><strong>Motif :</strong> ${reason}</p>` : ""}
+          ${buildCancellationBody(reason, outing.title, dateFormatted)}
           <p>Lieu : ${outing.location_details?.name || outing.location}</p>
           <p>Nous espérons vous retrouver lors d'une prochaine sortie !</p>
           <p>L'équipe Team Oxygen</p>


### PR DESCRIPTION
## Contexte

Suite à l'ajout des motifs d'annulation ([#218](https://github.com/karimsaari-data/deep-dive-planner/pull/218)), le mail d'annulation envoyé aux inscrits restait générique : une phrase unique (« … a été annulée. ») suivie d'une ligne « Motif : … », quel que soit le motif choisi.

## Changement

La edge function `send-outing-notification` génère désormais une **phrase d'annonce dédiée** selon le motif choisi :

| Motif | Message |
|-------|---------|
| Météo défavorable | « … est annulée en raison de conditions météo défavorables. La sécurité de tous reste notre priorité. » |
| Nombre d'inscrits insuffisant | « … est annulée faute d'un nombre suffisant d'inscrits pour la maintenir dans de bonnes conditions. » |
| Encadrant indisponible | « … est annulée en raison de l'indisponibilité de l'encadrant. » |
| Problème logistique | « … est annulée pour un problème logistique. » |
| Motif libre (autre) | Phrase générique + ligne « **Motif :** … » (comportement précédent) |

Aucun changement d'API : le motif est toujours passé via `reason` par le front.

## Déploiement

⚠️ La edge function doit être **redéployée sur Supabase** pour prendre effet (le merge Vercel ne déploie que le front).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzojHK5RnAHbk3UGCprZjV)_