### PR TITLE
fix: classer les encadrants d'une sortie par équipe encadrante, pas par diplôme

### DIFF
--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -323,11 +323,15 @@ const OutingDetail = () => {
     (apneaLevels || []).map(l => [l.code, l])
   );
 
-  // Sort participants: organizer first, then instructors (by member_status OR apnea level), then others
+  // Sort participants: organizer first, then encadrants (team encadrant), then others.
+  // "Team encadrant" = this outing's organizer, its co-encadrants, or a member whose
+  // member_status is "Encadrant" (admin-controlled). Holding an instructor-level diving
+  // qualification (apnea level flagged is_instructor) does NOT make someone an encadrant
+  // of the outing — e.g. a BPJEPS holder who is a simple member stays in the participants.
   const isReservationEncadrant = (r: typeof confirmedReservations[number]) => {
-    if (r.profile?.member_status === "Encadrant") return true;
-    const li = apneaLevelMap.get(r.profile?.apnea_level ?? "");
-    return li?.is_instructor ?? false;
+    if (r.user_id === outing.organizer_id) return true;
+    if (outing.co_instructors?.some((ci) => ci.user_id === r.user_id)) return true;
+    return r.profile?.member_status === "Encadrant";
   };
   const sortedConfirmed = [...confirmedReservations].sort((a, b) => {
     const aIsOrganizer = a.user_id === outing.organizer_id;
@@ -791,12 +795,15 @@ const OutingDetail = () => {
 
           {/* 2. Participants - enriched with instructor icons, organizer highlighted, apnea levels & depth */}
           {(() => {
-            // A person is an encadrant if their member_status = 'Encadrant' (admin-controlled, always up to date)
-            // OR if their apnea level is flagged as instructor in the apnea_levels table.
+            // A person is an encadrant of this outing if they are its organizer, one of its
+            // co-encadrants, or a member of the encadrant team (member_status = 'Encadrant',
+            // admin-controlled, always up to date). A diving qualification alone (apnea level
+            // flagged is_instructor) does NOT make someone an encadrant — e.g. a BPJEPS holder
+            // who is a simple member stays in the participants list.
             const isEncadrant = (r: typeof sortedConfirmed[number]) => {
-              if (r.profile?.member_status === "Encadrant") return true;
-              const li = apneaLevelMap.get(r.profile?.apnea_level ?? "");
-              return li?.is_instructor ?? false;
+              if (r.user_id === outing.organizer_id) return true;
+              if (outing.co_instructors?.some((ci) => ci.user_id === r.user_id)) return true;
+              return r.profile?.member_status === "Encadrant";
             };
 
             // Separate confirmed reservations into instructors and regular participants

--- a/src/pages/OutingView.tsx
+++ b/src/pages/OutingView.tsx
@@ -264,10 +264,10 @@ const OutingView = () => {
     if (aIsCoInstr && !bIsCoInstr) return -1;
     if (!aIsCoInstr && bIsCoInstr) return 1;
 
-    const aLevel = apneaLevelMap.get(a.profile?.apnea_level ?? "");
-    const bLevel = apneaLevelMap.get(b.profile?.apnea_level ?? "");
-    const aIsInstructor = aLevel?.is_instructor ?? false;
-    const bIsInstructor = bLevel?.is_instructor ?? false;
+    // Encadrant team members (member_status "Encadrant") before regular participants.
+    // A diving qualification alone does not make someone an encadrant of the outing.
+    const aIsInstructor = a.profile?.member_status === "Encadrant";
+    const bIsInstructor = b.profile?.member_status === "Encadrant";
     if (aIsInstructor && !bIsInstructor) return -1;
     if (!aIsInstructor && bIsInstructor) return 1;
     return 0;
@@ -651,7 +651,10 @@ const OutingView = () => {
                     const isOrg = reservation.user_id === organizerId;
                     const isCoInstr = coInstructorIds.has(reservation.user_id);
                     const levelInfo = apneaLevelMap.get(profile?.apnea_level ?? "");
-                    const isInstructor = levelInfo?.is_instructor ?? false;
+                    // Encadrant marker = team membership (organizer, co-encadrant, or
+                    // member_status "Encadrant"), NOT merely holding an instructor-level
+                    // diving qualification (e.g. a BPJEPS holder who is a simple member).
+                    const isInstructor = isOrg || isCoInstr || profile?.member_status === "Encadrant";
                     const depth = !isInstructor ? extractDepth(levelInfo?.prerogatives ?? null) : null;
 
                     return (


### PR DESCRIPTION
## Problème

Dans la **vue détail sortie** (`OutingDetail`) et la **vue sortie** (`OutingView`), une personne était classée « Encadrant » dès que son niveau d'apnée portait le flag `is_instructor` (ex. **BPJEPS**) — **en plus** de `member_status = "Encadrant"`.

Conséquence : un adhérent diplômé mais **pas membre de la team encadrant** apparaissait à tort dans la section **ENCADRANTS**. Cas signalé : **Alix NITHART** (BPJEPS, `member_status = "Membre"`) affichée en encadrant alors que la vue adhérent (`ParticipantsList`) la classait correctement dans les participants.

## Correctif

On aligne `OutingDetail` et `OutingView` sur la vue adhérent. Est encadrant **d'une sortie** uniquement :
1. l'organisateur de la sortie, **ou**
2. un co-encadrant de la sortie, **ou**
3. un membre dont `member_status = "Encadrant"` (source de vérité, gérée par l'admin).

Le diplôme d'encadrement seul (`is_instructor`) ne suffit plus à faire basculer quelqu'un dans les encadrants. La personne conserve son badge de niveau (ex. « BPJEPS ») mais reste dans les adhérents.

## Fichiers touchés
- `src/pages/OutingDetail.tsx` — helpers `isReservationEncadrant` (tri) et `isEncadrant` (regroupement + capacité).
- `src/pages/OutingView.tsx` — tri et marqueur encadrant (icône bouclier / badge).

## Vérifications
- `npm run build` : OK
- `npm run lint` : aucune nouvelle erreur introduite (les erreurs restantes sont préexistantes et hors périmètre).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nb1sjhz4x3tRTHQui3ooPC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nb1sjhz4x3tRTHQui3ooPC)_