### PR TITLE
fix: fuseau horaire Europe/Paris dans les dates des emails

### DIFF
--- a/supabase/functions/send-outing-notification/index.ts
+++ b/supabase/functions/send-outing-notification/index.ts
@@ -195,6 +195,7 @@ const handler = async (req: Request): Promise<Response> => {
         day: "numeric",
         hour: "2-digit",
         minute: "2-digit",
+        timeZone: "Europe/Paris",
       });
 
       const profile = reservation.profile as any;
@@ -249,6 +250,7 @@ const handler = async (req: Request): Promise<Response> => {
       day: "numeric",
       hour: "2-digit",
       minute: "2-digit",
+      timeZone: "Europe/Paris",
     });
 
     const emailResults = [];

--- a/supabase/functions/send-reminders/index.ts
+++ b/supabase/functions/send-reminders/index.ts
@@ -151,6 +151,7 @@ const handler = async (req: Request): Promise<Response> => {
         day: "numeric",
         hour: "2-digit",
         minute: "2-digit",
+        timeZone: "Europe/Paris",
       });
 
       for (const reservation of reservations ?? []) {

--- a/supabase/functions/send-reservation-confirmation/index.ts
+++ b/supabase/functions/send-reservation-confirmation/index.ts
@@ -123,6 +123,7 @@ const handler = async (req: Request): Promise<Response> => {
       day: "numeric",
       hour: "2-digit",
       minute: "2-digit",
+      timeZone: "Europe/Paris",
     });
 
     const fullName = `${profile.first_name} ${profile.last_name}`;


### PR DESCRIPTION
## Problème

Les emails affichaient l'heure des sorties **avec 2h de retard** (ex. « 06h30 » au lieu de « 08h30 » sur l'email de confirmation d'inscription).

Cause : les fonctions edge Deno s'exécutent en **UTC**. Les dates (`date_time`, stockées en `timestamptz`) étaient formatées avec `toLocaleDateString("fr-FR", …)` **sans option `timeZone`**, donc rendues en UTC au lieu de l'heure locale française (UTC+2 en été).

## Correctif

Ajout de `timeZone: "Europe/Paris"` à tous les formatages de date des emails :
- `send-reservation-confirmation` — inscription / liste d'attente / désinscription
- `send-reminders` — rappel 24h avant la sortie
- `send-outing-notification` — nouvelle sortie + email de retrait de participant (2 endroits)

L'heure affichée correspond désormais à l'heure de Paris quelle que soit l'horloge du serveur.

## ⚠️ Déploiement

Ces fonctions edge sont hébergées sur **Supabase** (pas Vercel) et **ne sont pas déployées automatiquement** par le merge. Elles doivent être redéployées sur le projet Supabase de prod pour que le correctif prenne effet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nb1sjhz4x3tRTHQui3ooPC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nb1sjhz4x3tRTHQui3ooPC)_