### PR TITLE
feat: planifier les rappels de sortie via pg_cron

### DIFF
--- a/supabase/functions/send-reminders/index.ts
+++ b/supabase/functions/send-reminders/index.ts
@@ -52,15 +52,28 @@ const handler = async (req: Request): Promise<Response> => {
     const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
 
-    // Authorization check: cron secret, service role key, or admin user
+    // Authorization check: cron secret, service role key, internal cron token, or admin user
     const authHeader = req.headers.get("Authorization");
-    
+    const bearer = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+    // Internal cron token: a random secret stored in Vault and sent by the pg_cron job.
+    // Validated via the service-role-only RPC public.check_reminders_token so the token
+    // never needs to be configured as a function env var.
+    let cronTokenValid = false;
+    if (bearer) {
+      const svc = createClient(supabaseUrl, supabaseServiceKey);
+      const { data } = await svc.rpc("check_reminders_token", { p_token: bearer });
+      cronTokenValid = data === true;
+    }
+
     // Check for cron secret authorization
     if (CRON_SECRET && authHeader === `Bearer ${CRON_SECRET}`) {
       console.log("Authorized via CRON_SECRET");
     } else if (authHeader === `Bearer ${supabaseServiceKey}`) {
       // Allow service role key for internal cron calls
       console.log("Authorized via SERVICE_ROLE_KEY (cron job)");
+    } else if (cronTokenValid) {
+      console.log("Authorized via internal cron token (Vault)");
     } else if (authHeader) {
       // Check for admin user authorization
       const supabaseAuth = createClient(supabaseUrl, supabaseAnonKey, {

--- a/supabase/migrations/20260711160000_schedule_outing_reminders.sql
+++ b/supabase/migrations/20260711160000_schedule_outing_reminders.sql
@@ -1,0 +1,75 @@
+-- Planification des rappels de sortie (24h avant) via pg_cron.
+--
+-- Contexte : la fonction edge `send-reminders` existait mais n'était jamais
+-- appelée (aucun job planifié) -> 0 rappel envoyé. On met en place un cron
+-- horaire qui déclenche la fonction. L'authentification se fait via un token
+-- interne aléatoire stocké dans Vault (jamais exposé dans le code ni dans la
+-- définition du job cron), validé par la fonction edge grâce à la RPC
+-- `check_reminders_token` (réservée au rôle service_role).
+
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+-- 1) Token interne stocké dans Vault (généré une seule fois, idempotent).
+do $$
+begin
+  if not exists (select 1 from vault.secrets where name = 'send_reminders_token') then
+    perform vault.create_secret(
+      gen_random_uuid()::text,
+      'send_reminders_token',
+      'Token interne utilisé par le cron pour authentifier les appels à la fonction edge send-reminders'
+    );
+  end if;
+end $$;
+
+-- 2) RPC de validation du token, réservée à service_role (appelée par la fonction edge).
+create or replace function public.check_reminders_token(p_token text)
+returns boolean
+language sql
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+    from vault.decrypted_secrets
+    where name = 'send_reminders_token'
+      and decrypted_secret = p_token
+  );
+$$;
+
+revoke all on function public.check_reminders_token(text) from public, anon, authenticated;
+grant execute on function public.check_reminders_token(text) to service_role;
+
+-- 3) Fonction déclencheur : lit le token dans Vault et POST vers la fonction edge.
+create or replace function public.trigger_send_reminders()
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_token text;
+begin
+  select decrypted_secret into v_token
+  from vault.decrypted_secrets
+  where name = 'send_reminders_token';
+
+  perform net.http_post(
+    url     := 'https://hyoudezyqbivfthcgpma.supabase.co/functions/v1/send-reminders',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || v_token
+    ),
+    body    := '{}'::jsonb
+  );
+end;
+$$;
+
+revoke all on function public.trigger_send_reminders() from public, anon, authenticated;
+
+-- 4) Planification horaire (upsert par nom, idempotent).
+select cron.schedule(
+  'send-reminders-hourly',
+  '0 * * * *',
+  $$ select public.trigger_send_reminders(); $$
+);


### PR DESCRIPTION
## Contexte

Les rappels 24h avant une sortie n'étaient **jamais envoyés** : la fonction edge `send-reminders` existait mais **aucun planificateur ne l'appelait** (0 rappel sur 21 sorties). Ce PR met en place le planificateur manquant.

## Ce que fait ce PR

- **Job `pg_cron` horaire** (`send-reminders-hourly`) qui déclenche la fonction edge `send-reminders`.
- **Authentification sans secret exposé** : un token aléatoire est stocké dans **Vault** et envoyé par le cron ; la fonction edge le valide via la RPC `check_reminders_token` (réservée à `service_role`). Le token n'apparaît ni dans le code, ni dans la définition du job cron.
- Fonction edge `send-reminders` : nouvelle branche d'auth acceptant ce token interne.

Couplé à la fenêtre glissante 24h (PR #222), chaque sortie reçoit son rappel **une seule fois**, ~24h avant.

## Fichiers
- `supabase/migrations/20260711160000_schedule_outing_reminders.sql` — extension pg_cron/pg_net, secret Vault (idempotent), RPC `check_reminders_token`, fonction `trigger_send_reminders`, job cron horaire.
- `supabase/functions/send-reminders/index.ts` — validation du token interne.

## Déploiement
Migration appliquée + fonction redéployée sur le projet Supabase de prod (hors pipeline Vercel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nb1sjhz4x3tRTHQui3ooPC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nb1sjhz4x3tRTHQui3ooPC)_