### PR TITLE
feat: affectation des inscrits en palanquées

### DIFF
--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -17,6 +17,7 @@ export interface Reservation {
   carpool_option: CarpoolOption;
   carpool_seats: number;
   is_present: boolean;
+  group_number: number | null;
   created_at: string;
   profile?: {
     first_name: string;
@@ -253,6 +254,7 @@ export const useOuting = (outingId: string) => {
             carpool_seats,
             cancelled_at,
             is_present,
+            group_number,
             created_at,
             profile:profiles(first_name, last_name, email, apnea_level, avatar_url, member_status)
           )
@@ -309,6 +311,7 @@ export interface OutingParticipant {
   member_status: string | null;
   status?: BookingStatus;
   created_at?: string;
+  group_number?: number | null;
 }
 
 export const useMyReservations = () => {
@@ -555,6 +558,34 @@ export const useUpdateReservationPresence = () => {
     },
     onError: (error: Error) => {
       toast.error(error.message || "Erreur lors de la mise à jour");
+    },
+  });
+};
+
+export const useSetReservationGroup = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      reservationId,
+      groupNumber,
+    }: {
+      reservationId: string;
+      groupNumber: number | null;
+    }) => {
+      const { error } = await supabase.rpc("set_reservation_group", {
+        p_reservation_id: reservationId,
+        p_group_number: groupNumber,
+      });
+
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["outing"] });
+      queryClient.invalidateQueries({ queryKey: ["my-reservations"] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Erreur lors de l'affectation de la palanquée");
     },
   });
 };

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -675,6 +675,7 @@ export type Database = {
           carpool_option: Database["public"]["Enums"]["carpool_option"] | null
           carpool_seats: number | null
           created_at: string | null
+          group_number: number | null
           id: string
           is_present: boolean | null
           outing_id: string
@@ -686,6 +687,7 @@ export type Database = {
           carpool_option?: Database["public"]["Enums"]["carpool_option"] | null
           carpool_seats?: number | null
           created_at?: string | null
+          group_number?: number | null
           id?: string
           is_present?: boolean | null
           outing_id: string
@@ -697,6 +699,7 @@ export type Database = {
           carpool_option?: Database["public"]["Enums"]["carpool_option"] | null
           carpool_seats?: number | null
           created_at?: string | null
+          group_number?: number | null
           id?: string
           is_present?: boolean | null
           outing_id?: string
@@ -794,11 +797,18 @@ export type Database = {
         Args: { outing_uuid: string }
         Returns: {
           avatar_url: string
+          created_at: string
           first_name: string
+          group_number: number
           id: string
           last_name: string
           member_status: string
+          status: string
         }[]
+      }
+      set_reservation_group: {
+        Args: { p_group_number: number; p_reservation_id: string }
+        Returns: undefined
       }
       get_trombinoscope_members: {
         Args: never

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -33,9 +33,16 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useAuth } from "@/contexts/AuthContext";
 import { useUserRole } from "@/hooks/useUserRole";
-import { useOuting, useUpdateReservationPresence, useUpdateSessionReport, useCancelOuting, useArchiveOuting, useLockPOSS, useUnlockPOSS, useAddCoInstructor, useRemoveCoInstructor, useDeleteOuting, useAdminRemoveReservation } from "@/hooks/useOutings";
+import { useOuting, useUpdateReservationPresence, useUpdateSessionReport, useCancelOuting, useArchiveOuting, useLockPOSS, useUnlockPOSS, useAddCoInstructor, useRemoveCoInstructor, useDeleteOuting, useAdminRemoveReservation, useSetReservationGroup } from "@/hooks/useOutings";
 import { usePOSSGenerator } from "@/hooks/usePOSSGenerator";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
@@ -61,6 +68,9 @@ const CANCEL_REASONS = [
   "Problème logistique",
 ];
 
+/** Numéros de palanquées proposés lors de l'affectation des inscrits */
+const PALANQUEE_NUMBERS = [1, 2, 3, 4, 5, 6];
+
 /** Extract max depth from prerogatives string */
 const extractDepth = (prerogatives: string | null): string | null => {
   if (!prerogatives) return null;
@@ -77,6 +87,7 @@ const OutingDetail = () => {
   const { isOrganizer, isAdmin, loading: roleLoading } = useUserRole();
   const { data: outing, isLoading } = useOuting(id ?? "");
   const updatePresence = useUpdateReservationPresence();
+  const setReservationGroup = useSetReservationGroup();
   const updateSessionReport = useUpdateSessionReport();
   const cancelOuting = useCancelOuting();
   const adminRemoveReservation = useAdminRemoveReservation();
@@ -908,6 +919,29 @@ const OutingDetail = () => {
                   </div>
 
                   <div className="flex items-center gap-2">
+                    {!isPast && canManageOuting && (
+                      <Select
+                        value={reservation.group_number ? String(reservation.group_number) : "none"}
+                        onValueChange={(v) =>
+                          setReservationGroup.mutate({
+                            reservationId: reservation.id,
+                            groupNumber: v === "none" ? null : Number(v),
+                          })
+                        }
+                      >
+                        <SelectTrigger className="h-8 w-[130px] text-xs">
+                          <SelectValue placeholder="Palanquée" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">Sans palanquée</SelectItem>
+                          {PALANQUEE_NUMBERS.map((n) => (
+                            <SelectItem key={n} value={String(n)}>
+                              Palanquée {n}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
                     {canMarkAttendance && canEditPresenceAndReport && (
                       <div className="flex items-center gap-2">
                         <Checkbox
@@ -990,6 +1024,57 @@ const OutingDetail = () => {
                   )}
                 </div>
               )}
+
+              {(() => {
+                const assigned = sortedConfirmed.filter((r) => r.group_number != null);
+                if (assigned.length === 0) return null;
+                const groupNumbers = [...new Set(assigned.map((r) => r.group_number as number))].sort(
+                  (a, b) => a - b
+                );
+                const unassignedCount = sortedConfirmed.length - assigned.length;
+                return (
+                  <div className="mt-6 border-t border-border/50 pt-4">
+                    <h4 className="mb-3 flex items-center gap-1.5 text-sm font-semibold text-foreground">
+                      <Users className="h-4 w-4 text-primary" />
+                      Palanquées
+                    </h4>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      {groupNumbers.map((n) => {
+                        const members = assigned.filter((r) => r.group_number === n);
+                        return (
+                          <div key={n} className="rounded-lg border border-border bg-muted/30 p-3">
+                            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-primary">
+                              Palanquée {n} ({members.length})
+                            </p>
+                            <div className="space-y-1.5">
+                              {members.map((r) => (
+                                <div key={r.id} className="flex items-center gap-1.5 text-sm">
+                                  {isEncadrant(r) && (
+                                    <Shield className="h-3.5 w-3.5 flex-shrink-0 text-amber-500" />
+                                  )}
+                                  <span className="text-foreground">
+                                    {formatFullName(r.profile?.first_name, r.profile?.last_name)}
+                                  </span>
+                                  {r.profile?.apnea_level && (
+                                    <Badge variant="outline" className="text-[10px] px-1 py-0">
+                                      {r.profile.apnea_level}
+                                    </Badge>
+                                  )}
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                    {unassignedCount > 0 && (
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        {unassignedCount} inscrit{unassignedCount > 1 ? "s" : ""} sans palanquée
+                      </p>
+                    )}
+                  </div>
+                );
+              })()}
 
               {waitlistedReservations.length > 0 && (
                 <div className="mt-6">

--- a/src/pages/Reservations.tsx
+++ b/src/pages/Reservations.tsx
@@ -139,6 +139,31 @@ const Reservations = () => {
                             </div>
                           </div>
 
+                          {/* Ma palanquée */}
+                          {(() => {
+                            const me = (reservation.participants ?? []).find((p) => p.id === user?.id);
+                            if (!me?.group_number) return null;
+                            const mates = (reservation.participants ?? []).filter(
+                              (p) =>
+                                p.group_number === me.group_number &&
+                                p.id !== user?.id &&
+                                p.status !== "en_attente"
+                            );
+                            return (
+                              <div className="mt-3 rounded-lg border border-primary/30 bg-primary/5 p-3">
+                                <div className="flex items-center gap-1.5 text-sm font-semibold text-primary">
+                                  <Users className="h-4 w-4" />
+                                  Ma palanquée : Palanquée {me.group_number}
+                                </div>
+                                {mates.length > 0 && (
+                                  <p className="mt-1 text-xs text-muted-foreground">
+                                    Avec {mates.map((p) => p.first_name).join(", ")}
+                                  </p>
+                                )}
+                              </div>
+                            );
+                          })()}
+
                           {/* Participants trombinoscope */}
                           {(() => {
                             // Co-instructors always shown as encadrants regardless of profile member_status

--- a/supabase/migrations/20260711170000_reservation_group_number.sql
+++ b/supabase/migrations/20260711170000_reservation_group_number.sql
@@ -1,0 +1,75 @@
+-- Palanquées : affectation des inscrits à un groupe en amont de la sortie.
+-- Modèle minimal : une simple colonne group_number (nullable) sur reservations.
+-- NULL = non affecté. 1, 2, 3... = numéro de palanquée.
+
+ALTER TABLE public.reservations
+  ADD COLUMN IF NOT EXISTS group_number integer;
+
+-- RPC d'affectation. L'UPDATE direct sur reservations est réservé par RLS à
+-- l'organisateur/admin ; cette fonction SECURITY DEFINER élargit le droit
+-- d'écrire UNIQUEMENT la colonne group_number à l'organisateur, à ses
+-- co-encadrants et aux admins.
+CREATE OR REPLACE FUNCTION public.set_reservation_group(
+  p_reservation_id uuid,
+  p_group_number integer
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_outing_id uuid;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  SELECT outing_id INTO v_outing_id
+  FROM public.reservations
+  WHERE id = p_reservation_id;
+
+  IF v_outing_id IS NULL THEN
+    RAISE EXCEPTION 'Reservation not found';
+  END IF;
+
+  IF NOT (
+    EXISTS (
+      SELECT 1 FROM public.outings
+      WHERE id = v_outing_id AND organizer_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.outing_co_instructors
+      WHERE outing_id = v_outing_id AND user_id = auth.uid()
+    )
+    OR public.has_role(auth.uid(), 'admin')
+  ) THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  UPDATE public.reservations
+  SET group_number = p_group_number
+  WHERE id = p_reservation_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.set_reservation_group(uuid, integer) TO authenticated;
+
+-- Expose group_number dans la liste des participants (utilisée par la vue
+-- « Mes Réservations » pour que chaque inscrit voie sa palanquée).
+DROP FUNCTION IF EXISTS public.get_outing_participants(uuid);
+CREATE FUNCTION public.get_outing_participants(outing_uuid uuid)
+RETURNS TABLE(id uuid, first_name text, last_name text, avatar_url text, member_status text, status text, created_at timestamptz, group_number integer)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $$
+  SELECT p.id, p.first_name, p.last_name, p.avatar_url, p.member_status::text,
+         r.status::text, r.created_at, r.group_number
+  FROM public.reservations r
+  JOIN public.profiles p ON r.user_id = p.id
+  WHERE r.outing_id = outing_uuid
+    AND r.status IN ('confirmé', 'en_attente')
+  ORDER BY
+    CASE WHEN r.status = 'confirmé' THEN 0 ELSE 1 END,
+    CASE WHEN p.member_status = 'Encadrant' THEN 0 ELSE 1 END,
+    r.created_at;
+$$;


### PR DESCRIPTION
## Quoi

Permet à l'organisateur **ou** à un co-encadrant d'affecter chaque inscrit d'une sortie à une **palanquée** en amont, de façon simple et sans aucun contrôle bloquant.

## Pourquoi

Besoin exprimé : former les groupes (palanquées) parmi les inscrits avant la sortie. Choix retenu : version minimale, l'encadrant compose à la main, pas de validation de capacité/profondeur.

## Changements

**Base de données** (migration `20260711170000_reservation_group_number.sql`, déjà appliquée en prod) :
- Colonne `reservations.group_number` (nullable — `NULL` = sans palanquée)
- RPC `set_reservation_group` (`SECURITY DEFINER`) autorisant organisateur, co-encadrants et admins à écrire ce seul champ
- `get_outing_participants` enrichi du `group_number`

**Front** :
- `OutingDetail` : sélecteur « Palanquée » sur chaque inscrit + récap groupé par palanquée
- `Reservations` : bloc « Ma palanquée » côté participant (visible immédiatement)
- `useOutings` : hook `useSetReservationGroup` + exposition du `group_number`
- `types.ts` : ajout du champ et de la fonction

## Vérifs

- `npm run build` ✅
- Migration vérifiée en base (colonne + signatures des fonctions) ✅
- Lint : seules alertes = `any` préexistants, aucune introduite

Hors périmètre (phase 2) : injection des palanquées dans le PDF du POSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pp63pa5u9DZp59kMyjftcW)_