### PR TITLE
refactor: renomme « Palanquée » en « Groupe » dans l'UI

### DIFF
--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -585,7 +585,7 @@ export const useSetReservationGroup = () => {
       queryClient.invalidateQueries({ queryKey: ["my-reservations"] });
     },
     onError: (error: Error) => {
-      toast.error(error.message || "Erreur lors de l'affectation de la palanquée");
+      toast.error(error.message || "Erreur lors de l'affectation du groupe");
     },
   });
 };

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -68,8 +68,8 @@ const CANCEL_REASONS = [
   "Problème logistique",
 ];
 
-/** Numéros de palanquées proposés lors de l'affectation des inscrits */
-const PALANQUEE_NUMBERS = [1, 2, 3, 4, 5, 6];
+/** Numéros de groupes proposés lors de l'affectation des inscrits */
+const GROUP_NUMBERS = [1, 2, 3, 4, 5, 6];
 
 /** Extract max depth from prerogatives string */
 const extractDepth = (prerogatives: string | null): string | null => {
@@ -930,13 +930,13 @@ const OutingDetail = () => {
                         }
                       >
                         <SelectTrigger className="h-8 w-[130px] text-xs">
-                          <SelectValue placeholder="Palanquée" />
+                          <SelectValue placeholder="Groupe" />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="none">Sans palanquée</SelectItem>
-                          {PALANQUEE_NUMBERS.map((n) => (
+                          <SelectItem value="none">Sans groupe</SelectItem>
+                          {GROUP_NUMBERS.map((n) => (
                             <SelectItem key={n} value={String(n)}>
-                              Palanquée {n}
+                              Groupe {n}
                             </SelectItem>
                           ))}
                         </SelectContent>
@@ -1036,7 +1036,7 @@ const OutingDetail = () => {
                   <div className="mt-6 border-t border-border/50 pt-4">
                     <h4 className="mb-3 flex items-center gap-1.5 text-sm font-semibold text-foreground">
                       <Users className="h-4 w-4 text-primary" />
-                      Palanquées
+                      Groupes
                     </h4>
                     <div className="grid gap-3 sm:grid-cols-2">
                       {groupNumbers.map((n) => {
@@ -1044,7 +1044,7 @@ const OutingDetail = () => {
                         return (
                           <div key={n} className="rounded-lg border border-border bg-muted/30 p-3">
                             <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-primary">
-                              Palanquée {n} ({members.length})
+                              Groupe {n} ({members.length})
                             </p>
                             <div className="space-y-1.5">
                               {members.map((r) => (
@@ -1069,7 +1069,7 @@ const OutingDetail = () => {
                     </div>
                     {unassignedCount > 0 && (
                       <p className="mt-2 text-xs text-muted-foreground">
-                        {unassignedCount} inscrit{unassignedCount > 1 ? "s" : ""} sans palanquée
+                        {unassignedCount} inscrit{unassignedCount > 1 ? "s" : ""} sans groupe
                       </p>
                     )}
                   </div>

--- a/src/pages/Reservations.tsx
+++ b/src/pages/Reservations.tsx
@@ -139,7 +139,7 @@ const Reservations = () => {
                             </div>
                           </div>
 
-                          {/* Ma palanquée */}
+                          {/* Mon groupe */}
                           {(() => {
                             const me = (reservation.participants ?? []).find((p) => p.id === user?.id);
                             if (!me?.group_number) return null;
@@ -153,7 +153,7 @@ const Reservations = () => {
                               <div className="mt-3 rounded-lg border border-primary/30 bg-primary/5 p-3">
                                 <div className="flex items-center gap-1.5 text-sm font-semibold text-primary">
                                   <Users className="h-4 w-4" />
-                                  Ma palanquée : Palanquée {me.group_number}
+                                  Mon groupe : Groupe {me.group_number}
                                 </div>
                                 {mates.length > 0 && (
                                   <p className="mt-1 text-xs text-muted-foreground">


### PR DESCRIPTION
## Quoi

Renomme le libellé **« Palanquée » → « Groupe »** dans toute l'interface de la fonctionnalité d'affectation des inscrits.

## Pourquoi

« Palanquée » est un terme de plongée bouteille (le groupe sous un guide de palanquée). En **apnée**, on parle de **groupe** (ensemble encadré) et de **binôme** (paire de sécurité). Le mot était donc inadapté.

## Changements

Libellés uniquement — le champ interne `group_number` et la logique base de données sont inchangés :
- `OutingDetail` : sélecteur, récap (« Groupes », « Groupe N »), « sans groupe »
- `Reservations` : « Mon groupe : Groupe N »
- `useOutings` : message d'erreur

## Vérifs

- `npm run build` ✅
- Aucune occurrence « palanqu » restante côté `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pp63pa5u9DZp59kMyjftcW)_