### PR TITLE
feat: liseré coloré par groupe + POSS colonne Groupe en 1er

### DIFF
--- a/src/components/poss/POSSGenerator.ts
+++ b/src/components/poss/POSSGenerator.ts
@@ -538,14 +538,14 @@ export const generatePOSS = async (data: POSSData): Promise<void> => {
   const norm = (s: string) => s.toLowerCase().replace(/\s+/g, " ").trim();
   const coNames = new Set(coInstructors.map((c) => norm(c.name)));
   const orgNorm = norm(organizerName);
-  const roleOf = (p: POSSParticipant): "RESP." | "Encadrant" | "" => {
+  const roleOf = (p: POSSParticipant): "RESP." | "Co-enc." | "" => {
     const full = norm(`${p.first_name} ${p.last_name}`);
     const reversed = norm(`${p.last_name} ${p.first_name}`);
     if (full === orgNorm || reversed === orgNorm) return "RESP.";
-    if (coNames.has(full) || coNames.has(reversed)) return "Encadrant";
+    if (coNames.has(full) || coNames.has(reversed)) return "Co-enc.";
     return "";
   };
-  const roleRank = (r: string) => (r === "RESP." ? 0 : r === "Encadrant" ? 1 : 2);
+  const roleRank = (r: string) => (r === "RESP." ? 0 : r === "Co-enc." ? 1 : 2);
 
   // La colonne « Groupe » n'est ajoutée que si des groupes ont été composés
   // pour cette sortie, afin de ne pas afficher une colonne vide sinon.
@@ -577,7 +577,7 @@ export const generatePOSS = async (data: POSSData): Promise<void> => {
         : "-",
     ];
     if (hasGroups) {
-      row.splice(1, 0, p.group_number ? `Groupe ${p.group_number}` : "—");
+      row.splice(0, 0, p.group_number ? `Groupe ${p.group_number}` : "—");
     }
     return row;
   });
@@ -586,12 +586,12 @@ export const generatePOSS = async (data: POSSData): Promise<void> => {
     ? ["", "", "Aucun participant", "", "", ""]
     : ["", "Aucun participant", "", "", ""];
   const head = hasGroups
-    ? [["Rôle", "Groupe", "NOM", "Prénom", "Niveau", "Contact Urgence"]]
+    ? [["Groupe", "Rôle", "NOM", "Prénom", "Niveau", "Contact Urgence"]]
     : [["Rôle", "NOM", "Prénom", "Niveau", "Contact Urgence"]];
   const columnStyles = hasGroups
     ? {
-        0: { cellWidth: 22, fontStyle: "bold" as const, halign: "center" as const },
-        1: { cellWidth: 24, fontStyle: "bold" as const, halign: "center" as const },
+        0: { cellWidth: 24, fontStyle: "bold" as const, halign: "center" as const },
+        1: { cellWidth: 22, fontStyle: "bold" as const, halign: "center" as const },
         2: { cellWidth: 38, fontStyle: "bold" as const },
         3: { cellWidth: 30 },
         4: { cellWidth: 40 },
@@ -629,13 +629,14 @@ export const generatePOSS = async (data: POSSData): Promise<void> => {
         if (role === "RESP.") {
           data.cell.styles.fillColor = "#fef3c7"; // jaune = responsable
           data.cell.styles.fontStyle = "bold";
-        } else if (role === "Encadrant") {
-          data.cell.styles.fillColor = "#dbeafe"; // bleu = encadrant
+        } else if (role === "Co-enc.") {
+          data.cell.styles.fillColor = "#dbeafe"; // bleu = co-encadrant
           data.cell.styles.fontStyle = "bold";
         }
-        // La cellule « Groupe » prend la couleur du groupe (prioritaire sur le
-        // rôle), créant une bande colorée par groupe puisque le tableau est trié.
-        if (hasGroups && data.column.index === 1 && entry.p.group_number != null) {
+        // La cellule « Groupe » (1re colonne) prend la couleur du groupe
+        // (prioritaire sur le rôle), créant une bande colorée par groupe
+        // puisque le tableau est trié.
+        if (hasGroups && data.column.index === 0 && entry.p.group_number != null) {
           data.cell.styles.fillColor = groupPdfColor(entry.p.group_number);
           data.cell.styles.fontStyle = "bold";
         }
@@ -651,8 +652,8 @@ export const generatePOSS = async (data: POSSData): Promise<void> => {
   doc.setFontSize(8);
   doc.setTextColor("#666666");
   const legendText = hasGroups
-    ? "Légende : surligné jaune = Responsable POSS  |  surligné bleu = Encadrant  |  colonne Groupe colorée = composition des groupes"
-    : "Légende : surligné jaune = Responsable POSS  |  surligné bleu = Encadrant";
+    ? "Légende : surligné jaune = Responsable POSS  |  surligné bleu = Co-encadrant  |  colonne Groupe colorée = composition des groupes"
+    : "Légende : surligné jaune = Responsable POSS  |  surligné bleu = Co-encadrant";
   doc.text(legendText, margin, y);
   doc.setTextColor("#000000");
 

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -86,6 +86,10 @@ const GROUP_COLORS = [
 ];
 const groupColor = (n: number) => GROUP_COLORS[(n - 1) % GROUP_COLORS.length];
 
+/** Couleurs vives correspondantes, pour le liseré à gauche des lignes inscrits */
+const GROUP_ACCENTS = ["#14b8a6", "#8b5cf6", "#f43f5e", "#10b981", "#f97316", "#0ea5e9"];
+const groupAccent = (n: number) => GROUP_ACCENTS[(n - 1) % GROUP_ACCENTS.length];
+
 /** Extract max depth from prerogatives string */
 const extractDepth = (prerogatives: string | null): string | null => {
   if (!prerogatives) return null;
@@ -862,6 +866,11 @@ const OutingDetail = () => {
                         ? "border-blue-200 bg-blue-50/60 dark:bg-blue-950/20 dark:border-blue-700"
                         : "border-border bg-muted/30"
                   }`}
+                  style={
+                    reservation.group_number
+                      ? { borderLeftWidth: 4, borderLeftColor: groupAccent(reservation.group_number) }
+                      : undefined
+                  }
                 >
                   <div className="flex min-w-0 items-center gap-3">
                     <button


### PR DESCRIPTION
## Quoi

Trois ajustements sur la fonctionnalité groupes.

## Changements

**Liste éditable des inscrits (page détail sortie)**
- Chaque ligne d'un inscrit affecté à un groupe reçoit un **liseré vif à gauche** de la couleur du groupe, pour relier visuellement la liste au récap coloré

**POSS**
- La colonne **« Groupe » passe en première position** (plus logique)
- Le rôle des **co-encadrants** est affiché **« Co-enc. » et surligné en bleu** (auparavant « Encadrant ») ; légende mise à jour

## Vérifs

- `npm run build` ✅
- Test headless POSS : ordre des colonnes (Groupe en 1er), largeurs 154 + 113 = 267 mm (pas de débordement), bande de couleur par groupe sur la 1re colonne, rôle « Co-enc. » bleu / responsable jaune — PDF généré sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pp63pa5u9DZp59kMyjftcW)_