### PR TITLE
feat: rendre le POSS accessible aux participants depuis l'appli

### DIFF
--- a/src/components/poss/POSSGenerator.ts
+++ b/src/components/poss/POSSGenerator.ts
@@ -179,8 +179,16 @@ const calculateDuration = (entryTime: string | null, exitTime: string | null): s
 const GROUP_PDF_COLORS = ["#ccfbf1", "#ede9fe", "#ffe4e6", "#d1fae5", "#ffedd5", "#e0f2fe"];
 const groupPdfColor = (n: number) => GROUP_PDF_COLORS[(n - 1) % GROUP_PDF_COLORS.length];
 
+// Résultat de la génération : le PDF téléchargé localement est aussi renvoyé
+// sous forme de blob (+ nom de fichier) pour pouvoir être archivé dans le
+// Storage et rendu accessible aux participants depuis l'appli.
+export interface POSSResult {
+  blob: Blob;
+  fileName: string;
+}
+
 // Main POSS Generator
-export const generatePOSS = async (data: POSSData): Promise<void> => {
+export const generatePOSS = async (data: POSSData): Promise<POSSResult> => {
   const { outingTitle, outingDateTime, outingLocation, outingType, diveMode, location, boat, waypoints, participants, organizerName, organizerLevel, organizerLevelName, organizerMaxDepthEaa, organizerMaxDepthEao, organizerPhone, coInstructors, waterEntryTime, waterExitTime, weather } = data;
   
   const doc = new jsPDF({
@@ -870,4 +878,7 @@ export const generatePOSS = async (data: POSSData): Promise<void> => {
   const siteName = location?.name?.replace(/\s+/g, "_") || "Sortie";
   const fileName = `POSS_${siteName}_${format(new Date(outingDateTime), "yyyy-MM-dd")}.pdf`;
   doc.save(fileName);
+
+  // Renvoie aussi le PDF pour archivage dans le Storage (accès participants).
+  return { blob: doc.output("blob"), fileName };
 };

--- a/src/hooks/useOutings.ts
+++ b/src/hooks/useOutings.ts
@@ -59,6 +59,8 @@ export interface Outing {
   is_archived?: boolean;
   is_staff_only?: boolean;
   is_poss_locked?: boolean;
+  poss_path?: string | null;
+  poss_generated_at?: string | null;
   dive_mode?: "boat" | "shore" | null;
   boat_id?: string | null;
   confirmed_count?: number; // Real count from SECURITY DEFINER function

--- a/src/hooks/usePOSSGenerator.ts
+++ b/src/hooks/usePOSSGenerator.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Outing, resolveCurrentSeasonApneaLevels } from "@/hooks/useOutings";
 import { Waypoint } from "@/hooks/useWaypoints";
@@ -10,6 +11,8 @@ interface UsePOSSGeneratorParams {
 }
 
 export const usePOSSGenerator = () => {
+  const queryClient = useQueryClient();
+
   const generate = async ({ outing, organizerName }: UsePOSSGeneratorParams) => {
     if (!outing) {
       toast.error("Données de sortie manquantes");
@@ -183,8 +186,33 @@ export const usePOSSGenerator = () => {
         weather: null, // TODO: integrate weather data from API
       };
 
-      // Generate the PDF
-      await generatePOSS(possData);
+      // Generate the PDF (téléchargé localement + blob renvoyé pour archivage)
+      const { blob } = await generatePOSS(possData);
+
+      // Archive le PDF dans le Storage privé et référence-le sur la sortie, afin
+      // que les participants inscrits puissent le consulter sans le régénérer.
+      try {
+        const filePath = `${outing.id}/poss.pdf`;
+        const { error: uploadError } = await supabase.storage
+          .from("poss")
+          .upload(filePath, blob, { upsert: true, contentType: "application/pdf" });
+
+        if (uploadError) throw uploadError;
+
+        const { error: updateError } = await supabase
+          .from("outings")
+          .update({ poss_path: filePath, poss_generated_at: new Date().toISOString() })
+          .eq("id", outing.id);
+
+        if (updateError) throw updateError;
+
+        queryClient.invalidateQueries({ queryKey: ["outing"] });
+        queryClient.invalidateQueries({ queryKey: ["outings"] });
+      } catch (storageError) {
+        // Le PDF a bien été téléchargé localement ; seul l'archivage a échoué.
+        console.error("Error archiving POSS:", storageError);
+        toast.warning("POSS téléchargé, mais son archivage pour les participants a échoué.");
+      }
 
       toast.success("POSS généré avec succès !");
     } catch (error) {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -532,6 +532,8 @@ export type Database = {
           organizer_member_id: string | null
           outing_type: Database["public"]["Enums"]["outing_type"]
           photos: string[] | null
+          poss_generated_at: string | null
+          poss_path: string | null
           reminder_sent: boolean | null
           session_report: string | null
           title: string
@@ -559,6 +561,8 @@ export type Database = {
           organizer_member_id?: string | null
           outing_type: Database["public"]["Enums"]["outing_type"]
           photos?: string[] | null
+          poss_generated_at?: string | null
+          poss_path?: string | null
           reminder_sent?: boolean | null
           session_report?: string | null
           title: string
@@ -586,6 +590,8 @@ export type Database = {
           organizer_member_id?: string | null
           outing_type?: Database["public"]["Enums"]["outing_type"]
           photos?: string[] | null
+          poss_generated_at?: string | null
+          poss_path?: string | null
           reminder_sent?: boolean | null
           session_report?: string | null
           title?: string

--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -303,6 +303,7 @@ const OutingDetail = () => {
   // Check if user is the organizer, co-instructor or admin of this outing
   const isOutingOrganizer = user?.id === outing.organizer_id;
   const isCoInstructor = outing.co_instructors?.some((ci) => ci.user_id === user?.id) ?? false;
+  const isConfirmedParticipant = confirmedReservations.some((r) => r.user_id === user?.id);
   const canManageOuting = isOutingOrganizer || isCoInstructor || isAdmin;
   const canEditPresenceAndReport = canManageOuting;
   const canCancelOuting = canManageOuting;
@@ -315,6 +316,19 @@ const OutingDetail = () => {
 
   const handleSaveReport = () => {
     updateSessionReport.mutate({ outingId: outing.id, sessionReport });
+  };
+
+  // Ouvre le POSS archivé (bucket privé) via une URL signée temporaire.
+  const handleViewPOSS = async () => {
+    if (!outing.poss_path) return;
+    const { data, error } = await supabase.storage
+      .from("poss")
+      .createSignedUrl(outing.poss_path, 3600);
+    if (error || !data?.signedUrl) {
+      toast.error("Impossible d'ouvrir le POSS.");
+      return;
+    }
+    window.open(data.signedUrl, "_blank", "noopener,noreferrer");
   };
 
   const handleCancelOuting = () => {
@@ -448,6 +462,18 @@ const OutingDetail = () => {
                 <Download className="h-4 w-4" />
                 Fiche Sécurité
               </Button>
+              {/* Voir le POSS archivé - participants inscrits + encadrement */}
+              {outing.poss_path && (canEditPresenceAndReport || isConfirmedParticipant) && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  onClick={handleViewPOSS}
+                >
+                  <FileText className="h-4 w-4" />
+                  Voir le POSS
+                </Button>
+              )}
               {/* Fiche évacuation - encadrants uniquement */}
               {canManageOuting && <FicheEvacuationGenerator compact />}
               {!isPast && canCancelOuting && (

--- a/supabase/migrations/20260711180000_poss_storage.sql
+++ b/supabase/migrations/20260711180000_poss_storage.sql
@@ -1,0 +1,64 @@
+-- POSS accessible depuis l'appli : on persiste le PDF généré dans un bucket
+-- Storage privé et on garde une référence + un horodatage sur la sortie, afin
+-- que tout participant inscrit puisse le consulter sans le régénérer.
+
+-- 1. Références sur la sortie
+ALTER TABLE public.outings
+  ADD COLUMN IF NOT EXISTS poss_path TEXT,
+  ADD COLUMN IF NOT EXISTS poss_generated_at TIMESTAMPTZ;
+
+-- 2. Bucket privé dédié aux POSS (données perso : contacts d'urgence, niveaux)
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('poss', 'poss', false)
+ON CONFLICT (id) DO NOTHING;
+
+-- 3. Politiques Storage
+-- Chemin de stockage : "<outing_id>/poss.pdf" -> le 1er segment est l'outing_id.
+
+-- Lecture : encadrement/admin OU participant confirmé de la sortie.
+CREATE POLICY "Participants and staff can view POSS"
+ON storage.objects FOR SELECT
+USING (
+  bucket_id = 'poss'
+  AND (
+    public.is_encadrant_or_admin(auth.uid())
+    OR EXISTS (
+      SELECT 1 FROM public.reservations r
+      WHERE r.outing_id = ((storage.foldername(name))[1])::uuid
+        AND r.user_id = auth.uid()
+        AND r.status = 'confirmé'
+    )
+  )
+);
+
+-- Écriture (upload, upsert, suppression) : réservée aux admins/organisateurs,
+-- même périmètre que l'UPDATE de la table outings (où l'on écrit poss_path).
+CREATE POLICY "Staff can upload POSS"
+ON storage.objects FOR INSERT
+WITH CHECK (
+  bucket_id = 'poss'
+  AND (
+    public.has_role(auth.uid(), 'admin')
+    OR public.has_role(auth.uid(), 'organizer')
+  )
+);
+
+CREATE POLICY "Staff can update POSS"
+ON storage.objects FOR UPDATE
+USING (
+  bucket_id = 'poss'
+  AND (
+    public.has_role(auth.uid(), 'admin')
+    OR public.has_role(auth.uid(), 'organizer')
+  )
+);
+
+CREATE POLICY "Staff can delete POSS"
+ON storage.objects FOR DELETE
+USING (
+  bucket_id = 'poss'
+  AND (
+    public.has_role(auth.uid(), 'admin')
+    OR public.has_role(auth.uid(), 'organizer')
+  )
+);


### PR DESCRIPTION
## Contexte

Le POSS d'une sortie était uniquement **téléchargé en local** au moment de la génération (`doc.save`), jamais persisté. Conséquences : impossible de le reconsulter sans le régénérer, et seuls les encadrants y avaient accès.

## Changements

- **Migration** (`supabase/migrations/20260711180000_poss_storage.sql`) :
  - Colonnes `outings.poss_path` + `outings.poss_generated_at`
  - Bucket Storage **privé** `poss`
  - RLS — lecture : encadrement **+ participants confirmés** ; écriture : admin/organisateur (même périmètre que le verrouillage POSS)
- **`POSSGenerator.ts`** : `generatePOSS` renvoie désormais le blob du PDF en plus du téléchargement local.
- **`usePOSSGenerator.ts`** : archive le PDF dans `poss/<outing_id>/poss.pdf` (upsert), référence `poss_path` sur la sortie, invalide le cache React Query.
- **`OutingDetail.tsx`** : bouton **« Voir le POSS »** (URL signée temporaire) visible par les participants inscrits et l'encadrement dès qu'un POSS est archivé.
- **`types.ts`** / interface `Outing` : ajout des deux nouvelles colonnes.

## Notes

- La migration DB (colonnes + bucket + policies) est **additive et non destructive** ; elle a déjà été appliquée sur le projet Supabase de prod.
- Le bouton n'apparaît que pour les POSS **générés après ce déploiement** : re-générer le POSS d'une sortie l'archive.

## Vérifications

- `npm run build` ✅
- Aucun nouveau problème de lint introduit par les fichiers modifiés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMSzpjrThsFEGtHA31iDuV)_