### PR TITLE
fix: respecter la limite de places saisie sur la page de détail d'une sortie

### DIFF
--- a/src/pages/OutingDetail.tsx
+++ b/src/pages/OutingDetail.tsx
@@ -865,13 +865,20 @@ const OutingDetail = () => {
             const confirmedInstructors = sortedConfirmed.filter(isEncadrant);
             const confirmedParticipants = sortedConfirmed.filter(r => !isEncadrant(r));
 
-            // Effective max = sum of each instructor's max_participants_encadrement
-            const effectiveMax = confirmedInstructors.length > 0
+            // Capacité théorique d'encadrement = somme des prérogatives
+            // (max_participants_encadrement) des encadrants effectivement présents.
+            const encadrementCapacity = confirmedInstructors.length > 0
               ? confirmedInstructors.reduce((sum, r) => {
                   const li = apneaLevelMap.get(r.profile?.apnea_level ?? "");
                   return sum + (li?.max_participants_encadrement ?? outing.max_participants);
                 }, 0)
               : outing.max_participants;
+            // La limite saisie par l'organisateur (outing.max_participants) fait foi :
+            // on ne dépasse jamais ce plafond, même si les prérogatives d'encadrement
+            // autorisent davantage. Sans ce Math.min, la page de détail affichait la
+            // capacité réglementaire (ex. 20 pour un BPJEPS) au lieu de la limite
+            // réellement fixée (ex. 5), d'où l'incohérence carte (/5) vs détail (/20).
+            const effectiveMax = Math.min(encadrementCapacity, outing.max_participants);
 
             const renderRow = (reservation: typeof sortedConfirmed[number]) => {
               const profile = reservation.profile;


### PR DESCRIPTION
## Problème

Sur une sortie où l'organisateur avait limité le nombre de places (ex. **5**), la **carte** affichait bien « 1/5 (4 places restantes) », mais la **page de détail** affichait « Participants confirmés (**1/20**) ».

## Cause

La page de détail (`OutingDetail.tsx`) ne se basait pas sur `outing.max_participants` (la limite saisie, = 5). Elle **recalculait** la capacité comme la **somme des prérogatives d'encadrement** (`max_participants_encadrement`) des encadrants présents. Jérémy étant **BPJEPS** (`max_participants_encadrement = 20`), la page affichait 20, écrasant la limite de 5.

La carte (`OutingCard.tsx`), elle, utilise directement `outing.max_participants` — d'où la divergence.

## Correctif

On plafonne la capacité affichée à la limite saisie par l'organisateur :

```js
const effectiveMax = Math.min(encadrementCapacity, outing.max_participants);
```

La limite manuelle fait désormais foi. Dans le cas normal où `max_participants` est déjà égal à la somme des prérogatives (mis à jour par le trigger `trg_recalculate_max_participants` lors de l'ajout de co-encadrants), le `Math.min` est neutre — le comportement multi-encadrants (badge « capacité ×N ») reste inchangé.

## Vérifications

- `npm run build` ✅
- Les 2 erreurs ESLint résiduelles sur `OutingDetail.tsx` (ligne 300, `cover_image_url as any`) sont préexistantes et hors périmètre de ce changement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vihnt6vgbH3Gyc8zVxGis5)_