### PR TITLE
fix: synchroniser la fin du RDV avec l'heure de sortie de l'eau

### DIFF
--- a/src/components/outings/EditOutingDialog.tsx
+++ b/src/components/outings/EditOutingDialog.tsx
@@ -54,6 +54,13 @@ const toTimeValue = (t: string | null | undefined): string | null => {
   return t.length === 5 ? t + ":00" : t;
 };
 
+// Add minutes to a "HH:MM" time, wrapping at 24h
+const addMinutes = (time: string, minutes: number): string => {
+  const [h, m] = time.split(":").map(Number);
+  const total = h * 60 + m + minutes;
+  return `${String(Math.floor(total / 60) % 24).padStart(2, "0")}:${String(total % 60).padStart(2, "0")}`;
+};
+
 interface EditOutingDialogProps {
   outing: Outing;
 }
@@ -376,7 +383,21 @@ const EditOutingDialog = ({ outing }: EditOutingDialogProps) => {
                   <FormItem>
                     <FormLabel>Heure sortie eau</FormLabel>
                     <FormControl>
-                      <Input type="time" {...field} />
+                      <Input
+                        type="time"
+                        {...field}
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          field.onChange(value);
+                          // Recalcule la fin du RDV (sortie de l'eau + 30 min pour rangement & départ)
+                          if (value) {
+                            form.setValue("endTime", addMinutes(value, 30), {
+                              shouldValidate: true,
+                              shouldDirty: true,
+                            });
+                          }
+                        }}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>


### PR DESCRIPTION
## Problème

Dans le formulaire de **modification** d'une sortie (`EditOutingDialog`), les champs « Heure sortie eau » et « Fin » étaient totalement indépendants. En modifiant l'heure de sortie de l'eau, la « Fin RDV » n'était pas recalculée — elle restait figée sur son ancienne valeur.

Résultat côté détail de la sortie : la timeline affichait « Sortie de l'eau » et « Fin RDV » à la même heure (ex. 11h30 → 11h30), au lieu de laisser 30 min de rangement & départ.

## Correctif

On rétablit la règle déjà appliquée dans le formulaire de **création** (`CreateOutingForm`), où la fin est toujours calculée comme *sortie de l'eau + 30 min*.

Désormais, dès qu'on modifie le champ « Heure sortie eau » dans le formulaire d'édition, le champ « Fin » est recalculé automatiquement (`sortie + 30 min`). La fin reste éditable manuellement ensuite si besoin.

## Vérifications

- `npm run build` ✅
- Modification limitée à `EditOutingDialog.tsx` ; les erreurs de lint restantes du fichier sont pré-existantes et hors du diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnBeJnbLb4xCMzNspNGhiS

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnBeJnbLb4xCMzNspNGhiS)_