### PR TITLE
fix: trier les sorties d'un membre par date décroissante dans les stats

### DIFF
--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -148,6 +148,11 @@ const Stats = () => {
         member.totalPresences++;
       });
 
+      // Sort each member's outings by date, most recent first
+      memberMap.forEach((member) => {
+        member.outings.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+      });
+
       return Array.from(memberMap.values()).sort((a, b) => b.totalPresences - a.totalPresences);
     },
     enabled: isAdmin,


### PR DESCRIPTION
## Problème

Dans **Statistiques → Participation**, le dialogue « Sorties de [membre] » affichait les sorties d'un membre dans un ordre arbitraire (ex. 14 juin, 05 juil., 12 juil., 30 mai, 17 mai…) au lieu du plus récent au plus ancien.

## Cause

La requête `memberPresences` (`src/pages/Stats.tsx`) construit `member.outings` en empilant les réservations dans l'ordre renvoyé par Supabase, sans aucun tri.

## Correctif

On trie désormais la liste de sorties de chaque membre par date, de la plus récente à la plus ancienne, avant de retourner les données.

## Vérification

- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017sUEsPvC34doDvNPTtAGeY)_