### PR TITLE
feat: détail cliquable des sorties par encadrant dans les stats

### DIFF
--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -43,6 +43,7 @@ interface OrganizerMonthly {
   name: string;
   months: number[];
   total: number;
+  outings: Array<{ id: string; title: string; date: string; role: string }>;
 }
 
 interface OutingListItem {
@@ -176,7 +177,8 @@ const Stats = () => {
           id: p.id,
           name: formatFullName(p.first_name, p.last_name),
           months: Array(12).fill(0),
-          total: 0
+          total: 0,
+          outings: []
         });
       });
 
@@ -193,12 +195,30 @@ const Stats = () => {
             id: row.profile_id,
             name: row.encadrant_name,
             months: Array(12).fill(0),
-            total: 0
+            total: 0,
+            outings: []
           });
         }
         const entry = organizerMap.get(row.profile_id)!;
         entry.months[row.month_index] += Number(row.outing_count);
         entry.total += Number(row.outing_count);
+      });
+
+      // Fetch the detailed list of outings per encadrant (sorted by date desc server-side)
+      const { data: detailRows, error: detailError } = await supabase
+        .rpc("get_encadrant_outings_detail", { p_year: selectedYear });
+      if (detailError) throw detailError;
+
+      (detailRows ?? []).forEach((row: { profile_id: string; outing_id: string; title: string; date_time: string; role: string }) => {
+        const entry = organizerMap.get(row.profile_id);
+        if (entry) {
+          entry.outings.push({
+            id: row.outing_id,
+            title: row.title,
+            date: row.date_time,
+            role: row.role,
+          });
+        }
       });
 
       return Array.from(organizerMap.values()).sort((a, b) => b.total - a.total);
@@ -895,7 +915,39 @@ const Stats = () => {
                           <TableBody>
                             {organizerMonthly?.map((organizer) => (
                               <TableRow key={organizer.id}>
-                                <TableCell className="font-medium">{organizer.name}</TableCell>
+                                <TableCell className="font-medium">
+                                  {organizer.outings.length > 0 ? (
+                                    <Dialog>
+                                      <DialogTrigger asChild>
+                                        <button className="text-left font-medium text-primary underline-offset-4 hover:underline">
+                                          {organizer.name}
+                                        </button>
+                                      </DialogTrigger>
+                                      <DialogContent>
+                                        <DialogHeader>
+                                          <DialogTitle>Sorties encadrées par {organizer.name}</DialogTitle>
+                                        </DialogHeader>
+                                        <div className="space-y-2 max-h-[60vh] overflow-y-auto">
+                                          {organizer.outings.map((outing) => (
+                                            <div key={`${outing.id}-${outing.role}`} className="flex items-center justify-between gap-2 border border-border rounded-lg p-3">
+                                              <div className="flex items-center gap-2 min-w-0">
+                                                <span className="font-medium truncate">{outing.title}</span>
+                                                {outing.role === "co_instructor" && (
+                                                  <Badge variant="outline" className="shrink-0 text-xs">Co-enc.</Badge>
+                                                )}
+                                              </div>
+                                              <Badge variant="outline" className="shrink-0">
+                                                {new Date(outing.date).toLocaleDateString("fr-FR", { day: "2-digit", month: "short", year: "numeric" })}
+                                              </Badge>
+                                            </div>
+                                          ))}
+                                        </div>
+                                      </DialogContent>
+                                    </Dialog>
+                                  ) : (
+                                    organizer.name
+                                  )}
+                                </TableCell>
                                 <TableCell className="text-center">
                                   <Badge variant="default">{organizer.total}</Badge>
                                 </TableCell>

--- a/supabase/migrations/20260719120000_get_encadrant_outings_detail.sql
+++ b/supabase/migrations/20260719120000_get_encadrant_outings_detail.sql
@@ -1,0 +1,53 @@
+-- RPC: liste détaillée des sorties encadrées par chaque encadrant pour une année.
+-- Compagnon de get_encadrant_monthly_stats : mêmes règles (sortie valide >= 2
+-- participants, rôle organisateur OU co-encadrant, sorties passées uniquement),
+-- afin que le détail affiché soit cohérent avec les totaux mensuels.
+-- Admin-only, SECURITY DEFINER. Tri par date décroissante (plus récent d'abord).
+CREATE OR REPLACE FUNCTION public.get_encadrant_outings_detail(p_year integer DEFAULT (EXTRACT(year FROM CURRENT_DATE))::integer)
+RETURNS TABLE (
+  profile_id UUID,
+  outing_id UUID,
+  title TEXT,
+  date_time TIMESTAMPTZ,
+  role TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  -- Verify caller is admin
+  IF NOT has_role(auth.uid(), 'admin') THEN
+    RAISE EXCEPTION 'Unauthorized: Admin access required';
+  END IF;
+
+  RETURN QUERY
+  WITH valid_outings AS (
+    SELECT o.id, o.organizer_id, o.title, o.date_time
+    FROM outings o
+    WHERE EXTRACT(YEAR FROM o.date_time) = p_year
+      AND o.date_time < NOW()
+      AND o.organizer_id IS NOT NULL
+      AND (
+        (SELECT COUNT(*) FROM reservations r
+          WHERE r.outing_id = o.id AND r.status = 'confirmé' AND r.is_present = true)
+        +
+        (SELECT COUNT(*) FROM historical_outing_participants h WHERE h.outing_id = o.id)
+      ) >= 2
+  ),
+  encadrant_outings AS (
+    SELECT vo.organizer_id AS profile_id, vo.id AS outing_id, vo.title, vo.date_time, 'organizer'::TEXT AS role
+    FROM valid_outings vo
+    UNION ALL
+    SELECT ci.user_id AS profile_id, vo.id AS outing_id, vo.title, vo.date_time, 'co_instructor'::TEXT AS role
+    FROM valid_outings vo
+    JOIN outing_co_instructors ci ON ci.outing_id = vo.id
+    WHERE ci.user_id <> vo.organizer_id
+  )
+  SELECT eo.profile_id, eo.outing_id, eo.title, eo.date_time, eo.role
+  FROM encadrant_outings eo
+  JOIN profiles p ON p.id = eo.profile_id
+  WHERE p.member_status = 'Encadrant'
+  ORDER BY eo.date_time DESC;
+END;
+$$;


### PR DESCRIPTION
## Demande

Dans **Statistiques → Encadrants**, le tableau n'affichait que les totaux mensuels. On souhaite pouvoir **sélectionner un encadrant pour voir le détail** de ses sorties.

## Changements

- Le nom de chaque encadrant devient **cliquable** et ouvre un dialogue « Sorties encadrées par [nom] » listant ses sorties, **triées par date décroissante** (plus récente en premier).
- Les sorties où l'encadrant intervient comme **co-encadrant** (et non organisateur) portent un badge `Co-enc.`.
- Nouvelle RPC `get_encadrant_outings_detail(p_year)`, compagnon de `get_encadrant_monthly_stats` : **mêmes règles de validité** (sortie passée, ≥ 2 participants, rôle organisateur ou co-encadrant), afin que le détail soit parfaitement cohérent avec les totaux mensuels déjà affichés. Admin-only, `SECURITY DEFINER`.

## Vérification

- Migration appliquée sur le projet Supabase ; totaux du détail vérifiés identiques aux totaux mensuels (ex. Karim SAARI = 8, Lara Hüe = 3).
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017sUEsPvC34doDvNPTtAGeY)_