### PR TITLE
fix: onglets des statistiques responsive sur mobile

### DIFF
--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -377,12 +377,12 @@ const Stats = () => {
           </div>
 
           <Tabs defaultValue="dashboard" className="space-y-6">
-            <TabsList className="grid w-full grid-cols-5">
-              <TabsTrigger value="dashboard">Tableau de bord</TabsTrigger>
-              <TabsTrigger value="demographics">Démographie</TabsTrigger>
-              <TabsTrigger value="members">Participation</TabsTrigger>
-              <TabsTrigger value="outings">Sorties</TabsTrigger>
-              <TabsTrigger value="organizers">Encadrants</TabsTrigger>
+            <TabsList className="grid h-auto w-full grid-cols-2 gap-1 sm:grid-cols-3 lg:grid-cols-5">
+              <TabsTrigger value="dashboard" className="whitespace-normal text-center">Tableau de bord</TabsTrigger>
+              <TabsTrigger value="demographics" className="whitespace-normal text-center">Démographie</TabsTrigger>
+              <TabsTrigger value="members" className="whitespace-normal text-center">Participation</TabsTrigger>
+              <TabsTrigger value="outings" className="whitespace-normal text-center">Sorties</TabsTrigger>
+              <TabsTrigger value="organizers" className="whitespace-normal text-center">Encadrants</TabsTrigger>
             </TabsList>
 
             {/* Dashboard Tab */}


### PR DESCRIPTION
## Problème

Sur mobile, dans **Statistiques**, la barre d'onglets (Tableau de bord / Démographie / Participation / Sorties / Encadrants) débordait : l'onglet « Encadrants » sortait du cadre et chevauchait le contenu en dessous.

## Cause

`TabsList` était en `grid-cols-5` avec la hauteur fixe `h-10` (défaut shadcn) et des libellés `whitespace-nowrap`. Les 5 libellés français longs ne rentrent pas sur une seule ligne étroite → débordement.

## Correctif

- Grille responsive : **2 colonnes sur mobile**, 3 en tablette (`sm`), 5 en desktop (`lg`).
- Hauteur automatique (`h-auto`) pour que le cadre s'adapte au nombre de lignes.
- Libellés `whitespace-normal` + `text-center` : ils peuvent passer à la ligne proprement dans leur cellule.

## Vérification

- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017sUEsPvC34doDvNPTtAGeY)_